### PR TITLE
Add additional win and lose conditions

### DIFF
--- a/Assets/Scripts/Battle/BattleManager.cs
+++ b/Assets/Scripts/Battle/BattleManager.cs
@@ -4,6 +4,18 @@ using UnityEngine;
 using Game.Input;
 using Game;
 
+public enum WinCondition
+{
+    DEFEAT_REQUIRED,
+    SURVIVE_TURNS
+}
+
+// additional lose conditions
+public enum SecondaryLoseCondition
+{
+    TOO_MANY_TURNS
+}
+
 [RequireComponent(typeof(PlayerTurnManager))]
 [RequireComponent(typeof(EnemyTurnManager))]
 [RequireComponent(typeof(PlayerUnitSetup))]
@@ -34,8 +46,12 @@ public class BattleManager : Singleton<BattleManager>
 
     #region Turn Queue
     private TurnQueue m_TurnQueue = new TurnQueue();
-    private HashSet<Unit> m_EnemyUnits = new HashSet<Unit>();
-    private HashSet<Unit> m_PlayerUnits = new HashSet<Unit>();
+    // TODO: This isn't actually required but given the data is still in flux right now
+    // I'm leaving this here
+    private HashSet<Unit> m_AllPlayerUnits = new HashSet<Unit>();
+    private HashSet<Unit> m_AllEnemyUnits = new HashSet<Unit>();
+    private HashSet<Unit> m_TrackedEnemyUnits = new HashSet<Unit>();
+    private HashSet<Unit> m_TrackedPlayerUnits = new HashSet<Unit>();
 
     private const float DELAY_TILL_NEXT_TURN = 0.3f;
     #endregion
@@ -44,6 +60,13 @@ public class BattleManager : Singleton<BattleManager>
     private bool m_BattleTick = false;
     private bool m_WithinBattle = false;
     private bool m_HasBattleConcluded = false;
+    #endregion
+
+    #region Battle Data
+    private WinCondition m_WinCondition;
+    private SecondaryLoseCondition[] m_SecondaryLoseCondition;
+    private float m_TurnsToSurvive;
+    private float m_MaxTurns;
     #endregion
 
     #region Camera
@@ -95,8 +118,15 @@ public class BattleManager : Singleton<BattleManager>
     public void InitialiseBattle(BattleSO battleSO, List<PlayerCharacterBattleData> playerUnitData, GameObject mapBiome)
     {
         m_TurnQueue.Clear();
-        m_EnemyUnits.Clear();
-        m_PlayerUnits.Clear();
+        m_AllPlayerUnits.Clear();
+        m_AllEnemyUnits.Clear();
+        m_TrackedEnemyUnits.Clear();
+        m_TrackedPlayerUnits.Clear();
+
+        m_WinCondition = battleSO.m_WinCondition;
+        m_SecondaryLoseCondition = battleSO.m_AdditionalLoseConditions;
+        m_TurnsToSurvive = battleSO.m_TurnsToSurvive;
+        m_MaxTurns = battleSO.m_MaxTurns;
 
         InstantiateBiome(mapBiome);
         StartCoroutine(BattleInitialise(battleSO, playerUnitData));
@@ -148,7 +178,9 @@ public class BattleManager : Singleton<BattleManager>
         enemyUnit.Initialise(unitPlacement.m_StatAugments, unitPlacement.m_EnemyCharacterData);
         m_MapLogic.PlaceUnit(GridType.ENEMY, enemyUnit, unitPlacement.m_Coordinates);
         m_TurnQueue.AddUnit(enemyUnit);
-        m_EnemyUnits.Add(enemyUnit);
+        m_AllEnemyUnits.Add(enemyUnit);
+        if (unitPlacement.m_DefeatRequired)
+            m_TrackedEnemyUnits.Add(enemyUnit);
     }
 
     /// <summary>
@@ -163,7 +195,9 @@ public class BattleManager : Singleton<BattleManager>
         playerUnit.Initialise(unitBattleData);
         m_MapLogic.PlaceUnit(GridType.PLAYER, playerUnit, position);
         m_TurnQueue.AddUnit(playerUnit);
-        m_PlayerUnits.Add(playerUnit);
+        m_AllPlayerUnits.Add(playerUnit);
+        if (unitBattleData.m_CannotDieWithoutLosingBattle)
+            m_TrackedPlayerUnits.Add(playerUnit);
     }
     #endregion
 
@@ -202,7 +236,7 @@ public class BattleManager : Singleton<BattleManager>
 
     private void EvaluateEnemyDecisions()
     {
-        foreach (var u in m_EnemyUnits)
+        foreach (var u in m_AllEnemyUnits)
         {
             var enemyUnit = u as EnemyUnit;
             enemyUnit.GetActionToBePerformed(m_MapLogic);
@@ -211,6 +245,42 @@ public class BattleManager : Singleton<BattleManager>
     #endregion
 
     #region BattleOutcome
+    private bool CheckForVictory()
+    {
+        switch (m_WinCondition)
+        {
+            case WinCondition.DEFEAT_REQUIRED:
+                return m_TrackedEnemyUnits.Count == 0;
+            case WinCondition.SURVIVE_TURNS:
+                return m_TurnQueue.GetCyclesElapsed() >= m_TurnsToSurvive;
+            default:
+                return false;
+        }
+    }
+
+    private bool CheckForDefeat(Unit felledUnit = null)
+    {
+        // check for tracked player unit death
+        if (felledUnit != null && m_TrackedPlayerUnits.Contains(felledUnit))
+            return true;
+
+        // check for no player units remaining
+        if (m_AllPlayerUnits.Count == 0)
+            return true;
+
+        foreach (SecondaryLoseCondition loseCondition in m_SecondaryLoseCondition)
+        {
+            switch (loseCondition)
+            {
+                case SecondaryLoseCondition.TOO_MANY_TURNS:
+                    if (m_TurnQueue.GetCyclesElapsed() >= m_MaxTurns)
+                        return true;
+                    break;
+            }
+        }
+        return false;
+    }
+
     private void CompleteBattle(UnitAllegiance victoriousSide)
     {
         // once a single battle end condition has been reached, don't re-invoke this method
@@ -244,20 +314,20 @@ public class BattleManager : Singleton<BattleManager>
 
         if (unit.UnitAllegiance == UnitAllegiance.PLAYER)
         {
-            m_PlayerUnits.Remove(unit);
+            m_AllPlayerUnits.Remove(unit);
             m_MapLogic.RemoveUnit(GridType.PLAYER, unit);
 
-            if (m_PlayerUnits.Count <= 0)
-            {
+            if (CheckForDefeat(unit))
                 CompleteBattle(UnitAllegiance.ENEMY);
-            }
         }
         else
         {
-            m_EnemyUnits.Remove(unit);
+            m_AllEnemyUnits.Remove(unit);
+            if (m_TrackedEnemyUnits.Contains(unit))
+                m_TrackedEnemyUnits.Remove(unit);
             m_MapLogic.RemoveUnit(GridType.ENEMY, unit);
 
-            if (m_EnemyUnits.Count <= 0)
+            if (CheckForVictory())
             {
                 CompleteBattle(UnitAllegiance.PLAYER);
             }
@@ -294,6 +364,19 @@ public class BattleManager : Singleton<BattleManager>
         if (m_TurnQueue.TryGetReadyUnit(out Unit readyUnit))
         {
             m_BattleTick = false;
+
+            if (CheckForVictory())
+            {
+                CompleteBattle(UnitAllegiance.PLAYER);
+                return;
+            }
+
+            if (CheckForDefeat())
+            {
+                CompleteBattle(UnitAllegiance.ENEMY);
+                return;
+            }
+
             StartTurn(readyUnit);
             return;
         }

--- a/Assets/Scripts/Battle/BattleManager.cs
+++ b/Assets/Scripts/Battle/BattleManager.cs
@@ -50,8 +50,6 @@ public class BattleManager : Singleton<BattleManager>
     // I'm leaving this here
     private HashSet<Unit> m_AllPlayerUnits = new HashSet<Unit>();
     private HashSet<Unit> m_AllEnemyUnits = new HashSet<Unit>();
-    private HashSet<Unit> m_TrackedEnemyUnits = new HashSet<Unit>();
-    private HashSet<Unit> m_TrackedPlayerUnits = new HashSet<Unit>();
 
     private const float DELAY_TILL_NEXT_TURN = 0.3f;
     #endregion
@@ -62,10 +60,15 @@ public class BattleManager : Singleton<BattleManager>
     private bool m_HasBattleConcluded = false;
     #endregion
 
-    #region Battle Data
+    #region Win Condition
     private WinCondition m_WinCondition;
-    private SecondaryLoseCondition[] m_SecondaryLoseCondition;
     private float m_TurnsToSurvive;
+    private HashSet<Unit> m_TrackedEnemyUnits = new HashSet<Unit>();
+    #endregion
+
+    #region Lose Condition
+    private HashSet<Unit> m_TrackedPlayerUnits = new HashSet<Unit>();
+    private SecondaryLoseCondition[] m_SecondaryLoseCondition;
     private float m_MaxTurns;
     #endregion
 
@@ -245,19 +248,25 @@ public class BattleManager : Singleton<BattleManager>
     #endregion
 
     #region BattleOutcome
+    /// <summary>
+    /// Check the current battle state and determine if victory has been reached
+    /// </summary>
+    /// <returns></returns>
     private bool CheckForVictory()
     {
-        switch (m_WinCondition)
+        return m_WinCondition switch
         {
-            case WinCondition.DEFEAT_REQUIRED:
-                return m_TrackedEnemyUnits.Count == 0;
-            case WinCondition.SURVIVE_TURNS:
-                return m_TurnQueue.GetCyclesElapsed() >= m_TurnsToSurvive;
-            default:
-                return false;
-        }
+            WinCondition.DEFEAT_REQUIRED => m_TrackedEnemyUnits.Count == 0,
+            WinCondition.SURVIVE_TURNS => m_TurnQueue.GetCyclesElapsed() >= m_TurnsToSurvive,
+            _ => false
+        };
     }
 
+    /// <summary>
+    /// Check the current battle state and determine if the player has been defeated
+    /// </summary>
+    /// <param name="felledUnit"></param>
+    /// <returns></returns>
     private bool CheckForDefeat(Unit felledUnit = null)
     {
         // check for tracked player unit death

--- a/Assets/Scripts/Battle/BattleSO.cs
+++ b/Assets/Scripts/Battle/BattleSO.cs
@@ -29,12 +29,14 @@ public class BattleSO : ScriptableObject
     [Header("Win Conditions")]
     // only one win condition is allowed
     public WinCondition m_WinCondition = WinCondition.DEFEAT_REQUIRED;
+    [Space]
     [Tooltip("Number of turns the player needs to survive - this is ignored if the win condition is not SURVIVE_TURNS")]
     public float m_TurnsToSurvive = 25f;
 
     [Header("Lose conditions")]
     [Tooltip("Secondary lose conditions apart from certain units being defeated")]
     public SecondaryLoseCondition[] m_AdditionalLoseConditions;
+    [Space]
     [Tooltip("Maximum number of turns the player is given to complete the battle - this is ignored if TOO_MANY_TURNS is not one of the secondary lose conditions")]
     // note: this should not be mixed with a win condition of SURVIVE_TURNS.
     public float m_MaxTurns = 25f;

--- a/Assets/Scripts/Battle/BattleSO.cs
+++ b/Assets/Scripts/Battle/BattleSO.cs
@@ -2,11 +2,13 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [System.Serializable]
-public struct EnemyUnitPlacement
+public class EnemyUnitPlacement
 {
     public CoordPair m_Coordinates;
     public EnemyCharacterSO m_EnemyCharacterData;
     public Stats m_StatAugments;
+    [Tooltip("Whether this unit needs to be defeated for the battle to be considered done - this is ignored if the win condition is not to defeat required units")]
+    public bool m_DefeatRequired = true;
 
     public UnitModelData GetUnitModelData()
     {
@@ -23,4 +25,17 @@ public class BattleSO : ScriptableObject
     /// </summary>
     public List<CoordPair> m_PlayerStartingTiles;
     public int m_ExpReward;
+
+    [Header("Win Conditions")]
+    // only one win condition is allowed
+    public WinCondition m_WinCondition = WinCondition.DEFEAT_REQUIRED;
+    [Tooltip("Number of turns the player needs to survive - this is ignored if the win condition is not SURVIVE_TURNS")]
+    public float m_TurnsToSurvive = 25f;
+
+    [Header("Lose conditions")]
+    [Tooltip("Secondary lose conditions apart from certain units being defeated")]
+    public SecondaryLoseCondition[] m_AdditionalLoseConditions;
+    [Tooltip("Maximum number of turns the player is given to complete the battle - this is ignored if TOO_MANY_TURNS is not one of the secondary lose conditions")]
+    // note: this should not be mixed with a win condition of SURVIVE_TURNS.
+    public float m_MaxTurns = 25f;
 }

--- a/Assets/Scripts/Battle/Grid/GridLogic.cs
+++ b/Assets/Scripts/Battle/Grid/GridLogic.cs
@@ -397,7 +397,7 @@ public class GridLogic : MonoBehaviour
                 for (int i = 0; i < summonPositions.Count; ++i)
                 {
                     // TODO: Possible animation delay
-                    BattleManager.Instance.InstantiateEnemyUnit(new() {m_Coordinates = summonPositions[i], m_EnemyCharacterData = summon.m_Adds[i].m_EnemyCharacterSO, m_StatAugments = summon.m_Adds[i].m_StatAugments});
+                    BattleManager.Instance.InstantiateEnemyUnit(new() {m_Coordinates = summonPositions[i], m_EnemyCharacterData = summon.m_Adds[i].m_EnemyCharacterSO, m_StatAugments = summon.m_Adds[i].m_StatAugments, m_DefeatRequired = false});
                 }
             }
         }

--- a/Assets/Scripts/Persistent Data/Character/PlayerCharacterData.cs
+++ b/Assets/Scripts/Persistent Data/Character/PlayerCharacterData.cs
@@ -31,6 +31,7 @@ public class PlayerCharacterData
     public GrowthRate TotalGrowthRate => m_BaseData.m_GrowthRates.FlatAugment(m_CurrClass.m_GrowthRateAugments);
 
     public int Id => m_BaseData.m_Id;
+    public bool IsLord => m_BaseData.m_IsLord;
 
     /// <summary>
     /// Total base stats accounting for both character's current stats with equipped class' flat augments
@@ -45,7 +46,7 @@ public class PlayerCharacterData
 
     public PlayerCharacterBattleData GetBattleData()
     {
-        return new PlayerCharacterBattleData(m_BaseData, TotalBaseStats, m_CurrClass, GetWeaponInstanceSO());
+        return new PlayerCharacterBattleData(m_BaseData, TotalBaseStats, m_CurrClass, GetWeaponInstanceSO(), IsLord);
     }
 
     private WeaponInstanceSO GetWeaponInstanceSO()
@@ -71,12 +72,19 @@ public struct PlayerCharacterBattleData
 
     public WeaponInstanceSO m_CurrEquippedWeapon;
 
-    public PlayerCharacterBattleData(PlayerCharacterSO baseData, Stats currStats, PlayerClassSO classSO, WeaponInstanceSO currEquippedWeapon)
+    /// <summary>
+    /// Whether this player unit should be tracked in battle. Once this unit dies, the battle is considered lost.
+    /// This could be due to a variety of reasons, e.g. the unit is a lord etc.
+    /// </summary>
+    public bool m_CannotDieWithoutLosingBattle;
+
+    public PlayerCharacterBattleData(PlayerCharacterSO baseData, Stats currStats, PlayerClassSO classSO, WeaponInstanceSO currEquippedWeapon, bool cannotDieWithoutLosingBattle)
     {
         m_BaseData = baseData;
         m_CurrStats = currStats;
         m_ClassSO = classSO;
         m_CurrEquippedWeapon = currEquippedWeapon;
+        m_CannotDieWithoutLosingBattle = cannotDieWithoutLosingBattle;
     }
 
     public UnitModelData GetUnitModelData()

--- a/Assets/Scripts/Persistent Data/Character/PlayerCharacterSO.cs
+++ b/Assets/Scripts/Persistent Data/Character/PlayerCharacterSO.cs
@@ -12,6 +12,9 @@ public class PlayerCharacterSO : CharacterSO
     [Tooltip("Growth rates for each stat - how growth rates work is that once the internally tracked progress of each stat reaches an arbitrary value, a single stat point is added to their base stats. Growth rates control how fast the internal progress grows.")]
     public GrowthRate m_GrowthRates;
 
+    [Tooltip("The lord cannot die in battle, or the battle is lost")]
+    public bool m_IsLord;
+
     public UnitModelData GetUnitModelData(OutfitType outfitType)
     {
         return m_Race.GetUnitModelData(m_Gender, outfitType);


### PR DESCRIPTION
- Win condition: Track only enemy units that need to be defeated (can be indicated on the `EnemyUnitPlacement` in BattleSO; defaults to true)
- Win condition: Survive set number of turns (cycles)
- Lose condition: Any player unit required to be kept alive dies
  * Right now only lords are required to be kept alive, a `PlayerCharacter` can be indicated as a lord at the `PlayerCharacterSO` level 
- Lose condition: Take too many turns (cycles) to complete the win condition