### PR TITLE
Add attacker range visual

### DIFF
--- a/Assets/Scripts/Battle/Map/MapLogic.cs
+++ b/Assets/Scripts/Battle/Map/MapLogic.cs
@@ -200,14 +200,14 @@ public class MapLogic : MonoBehaviour
         RetrieveGrid(gridType).PerformTeleportSkill(attacker, attack, targetTile, teleportTargetTile, completeSkillEvent);
     }
 
-    public bool IsValidSkillTargetTile(ActiveSkillSO activeSkillSO, Unit unit, CoordPair targetTile, GridType gridType, bool checkOccupied = false)
-    {
-        return RetrieveGrid(gridType).IsValidSkillTargetTile(activeSkillSO, unit, targetTile, checkOccupied);
-    }
-
     public bool IsValidTeleportTile(ActiveSkillSO activeSkillSO, Unit unit, CoordPair targetTile, GridType gridType)
     {
         return RetrieveGrid(gridType).IsValidTeleportTile(activeSkillSO, unit, targetTile);
+    }
+
+    public bool CanPerformSkill(ActiveSkillSO activeSkillSO, Unit unit, CoordPair targetTile, GridType gridType, bool checkOccupied = false)
+    {
+        return RetrieveGrid(gridType).CanPerformSkill(activeSkillSO, unit, targetTile, checkOccupied);
     }
     #endregion
 

--- a/Assets/Scripts/Battle/TurnManagement/PlayerTurnManager.cs
+++ b/Assets/Scripts/Battle/TurnManagement/PlayerTurnManager.cs
@@ -185,7 +185,7 @@ public class PlayerTurnManager : TurnManager
     {
         if (selectedTileData == null || selectedTileVisual == null) return;
 
-        if (m_MapLogic.IsValidSkillTargetTile(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType))
+        if (m_MapLogic.CanPerformSkill(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType))
         {
             m_MapLogic.SetTarget(selectedTileVisual.GridType, SelectedSkill, selectedTileVisual.Coordinates);
         }
@@ -258,7 +258,7 @@ public class PlayerTurnManager : TurnManager
     {
         if (selectedTileData == null || selectedTileVisual == null) return false;
 
-        if (m_MapLogic.IsValidSkillTargetTile(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType, true))
+        if (m_MapLogic.CanPerformSkill(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType, true))
         {
             if (selectedSkill.ContainsSkillType(SkillEffectType.TELEPORT))
             {

--- a/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillActionSO.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillActionSO.cs
@@ -41,12 +41,12 @@ public class EnemyActiveSkillActionWrapper : EnemyActionWrapper
             for (int c = 0; c < MapData.NUM_COLS; ++c)
             {
                 CoordPair coordinates = new CoordPair(r, c);
-                if (mapLogic.IsValidSkillTargetTile(activeSKill, enemyUnit, coordinates, targetGridType, true))
+                if (mapLogic.CanPerformSkill(activeSKill, enemyUnit, coordinates, targetGridType, true))
                 {
                     m_PossibleAttackPositions.Add(coordinates);
                     hasPossibleAttackPosition = true;
                 }
-                if (mapLogic.IsValidSkillTargetTile(activeSKill, enemyUnit, coordinates, targetGridType, false))
+                if (mapLogic.CanPerformSkill(activeSKill, enemyUnit, coordinates, targetGridType, false))
                 {
                     m_PossibleAttackPositionsIgnoreOccupied.Add(coordinates);
                 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/AttackerColLimitRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/AttackerColLimitRuleSO.cs
@@ -6,8 +6,8 @@ public class AttackerColLimitRuleSO : AttackerLocationRuleSO
 {
     public int[] m_AllowedAttackerCols;
 
-    public override bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType)
+    public override bool IsValidAttackerTile(CoordPair attackerPosition)
     {
-        return m_AllowedAttackerCols.Contains(attackingUnit.CurrPosition.m_Col);
+        return m_AllowedAttackerCols.Contains(attackerPosition.m_Col);
     }
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/AttackerRowLimitRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/AttackerRowLimitRuleSO.cs
@@ -6,8 +6,8 @@ public class AttackerRowLimitRuleSO : AttackerLocationRuleSO
 {
     public int[] m_AllowedAttackerRows;
 
-    public override bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType)
+    public override bool IsValidAttackerTile(CoordPair attackerPosition)
     {
-        return m_AllowedAttackerRows.Contains(attackingUnit.CurrPosition.m_Row);
+        return m_AllowedAttackerRows.Contains(attackerPosition.m_Row);
     }
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/AttackerLocationRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/AttackerLocationRuleSO.cs
@@ -1,1 +1,3 @@
-public abstract class AttackerLocationRuleSO : LocationTargetRuleSO {}
+public abstract class AttackerLocationRuleSO : LocationTargetRuleSO, IAttackerRule {
+    public abstract bool IsValidAttackerTile(CoordPair attackerPosition);
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/Interfaces.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/Interfaces.cs
@@ -1,0 +1,9 @@
+public interface ITargetRule
+{
+    public bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType);
+}
+
+public interface IAttackerRule
+{
+    public bool IsValidAttackerTile(CoordPair unitPosition);
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/Interfaces.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/Interfaces.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83e344dd0414d4a429205234770d6f3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/SkillTargetRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/SkillTargetRuleSO.cs
@@ -1,6 +1,3 @@
 using UnityEngine;
 
-public abstract class SkillTargetRuleSO : ScriptableObject
-{
-    public abstract bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType);
-}
+public abstract class SkillTargetRuleSO : ScriptableObject {}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/TargetLocationRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/TargetLocationRuleSO.cs
@@ -1,1 +1,3 @@
-public abstract class TargetLocationRuleSO : LocationTargetRuleSO {}
+public abstract class TargetLocationRuleSO : LocationTargetRuleSO, ITargetRule {
+    public abstract bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType);
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/TargetSideLimitRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/Definitions/TargetSideLimitRuleSO.cs
@@ -1,1 +1,3 @@
-public abstract class TargetSideLimitRuleSO : SkillTargetRuleSO {}
+public abstract class TargetSideLimitRuleSO : SkillTargetRuleSO, ITargetRule {
+    public abstract bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType);
+}


### PR DESCRIPTION
* Separate checks for valid target versus valid attacker (both are checked when performing a skill)
* Show both attacker range and target range for each active skill
   * Attacker range is only shown if there are limits on attacker range
   * Currently using enemy attack forecast effect, can be changed 