### PR TITLE
Implement skill cooldowns

### DIFF
--- a/Assets/Prefabs/UI/HUD/ActionMenu/ActionMenu.prefab
+++ b/Assets/Prefabs/UI/HUD/ActionMenu/ActionMenu.prefab
@@ -1765,10 +1765,10 @@ RectTransform:
   m_Children:
   - {fileID: 7851716745201225272}
   - {fileID: 1281721809369783611}
-  - {fileID: 8331579842007043515}
-  - {fileID: 2993469513773701629}
-  - {fileID: 580906455497798857}
-  - {fileID: 3570797669144144003}
+  - {fileID: 5456795195739684943}
+  - {fileID: 1274282580141446153}
+  - {fileID: 3470607074878077245}
+  - {fileID: 696892903785293175}
   - {fileID: 8003957493612957651}
   - {fileID: 2429613804939731398}
   - {fileID: 3338242524831069675}
@@ -2332,10 +2332,10 @@ MonoBehaviour:
   actionConfirmKeys: {fileID: 6250125083705366841}
   leftScrollButton: {fileID: 6797795080097878091}
   skillButtons:
-  - {fileID: 4323664633066422475}
-  - {fileID: 7356059360193926285}
-  - {fileID: 5156835968960428473}
-  - {fileID: 9084055279042799091}
+  - {fileID: 8595861069374564250}
+  - {fileID: 3269583683064820700}
+  - {fileID: 926297826380603112}
+  - {fileID: 3844684502621061794}
   rightScrollButton: {fileID: 2345475203084763811}
   moveButton: {fileID: 7047245327318005915}
   inspectButton: {fileID: 3733424629391839551}
@@ -2388,7 +2388,7 @@ MonoBehaviour:
   m_HideOnAwake: 1
   m_IsInteractable: 1
   m_BlocksRaycast: 1
-  m_CompletionBuffer: 0.1
+  m_HasIdleAnim: 0
 --- !u!1 &7389980225670677924
 GameObject:
   m_ObjectHideFlags: 0
@@ -2867,252 +2867,242 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6582809304549601204}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
-      propertyPath: m_Color.r
-      value: 1
+      propertyPath: m_AnchorMax.y
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326029618138082384, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_text
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
@@ -3121,25 +3111,25 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!224 &580906455497798857 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 2111613263845861713}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5156835968960428473 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &926297826380603112 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2111613263845861713}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &3470607074878077245 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2111613263845861713}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2651560024132121883
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3148,252 +3138,242 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6582809304549601204}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
-      propertyPath: m_Color.r
-      value: 1
+      propertyPath: m_AnchorMax.y
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326029618138082384, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_text
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
@@ -3402,23 +3382,23 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!224 &3570797669144144003 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &696892903785293175 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2651560024132121883}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &9084055279042799091 stripped
+--- !u!114 &3844684502621061794 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2651560024132121883}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &3421837939299662842
@@ -4022,252 +4002,242 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6582809304549601204}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
-      propertyPath: m_Color.r
-      value: 1
+      propertyPath: m_AnchorMax.y
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326029618138082384, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_text
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
@@ -4276,23 +4246,23 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!224 &2993469513773701629 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &1274282580141446153 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 4379978155311826021}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &7356059360193926285 stripped
+--- !u!114 &3269583683064820700 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 4379978155311826021}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &7412232285560688675
@@ -4303,252 +4273,252 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6582809304549601204}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
-      propertyPath: m_Color.r
-      value: 1
+      propertyPath: m_AnchorMax.y
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1270492913477276545, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4960944485450158857, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3326029618138082384, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_text
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 7709142133843600753, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8345162756728015001, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_FillAmount
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0
@@ -4557,25 +4527,25 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &4323664633066422475 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &5456795195739684943 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7412232285560688675}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8595861069374564250 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7412232285560688675}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8331579842007043515 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7412232285560688675}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7571393225265938903
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/HUD/ActionMenu/SkillButton.prefab
+++ b/Assets/Prefabs/UI/HUD/ActionMenu/SkillButton.prefab
@@ -1,0 +1,745 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2395138189215221925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9109684206142322495}
+  - component: {fileID: 8901200765095339354}
+  - component: {fileID: 8345162756728015001}
+  m_Layer: 0
+  m_Name: FillIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9109684206142322495
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2395138189215221925}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4836416610268862496}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -4, y: -4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8901200765095339354
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2395138189215221925}
+  m_CullTransparentMesh: 1
+--- !u!114 &8345162756728015001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2395138189215221925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -97088158288067470, guid: 252e5e02ea1c1674bb61c4b536890029, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5045841842879303489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2701963088895337268}
+  - component: {fileID: 7553270965548282928}
+  - component: {fileID: 5048066450159293702}
+  - component: {fileID: 3512309186563616715}
+  m_Layer: 0
+  m_Name: TMP_CooldownText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2701963088895337268
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5045841842879303489}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4836416610268862496}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.033333335, y: 0.022222228}
+  m_AnchorMax: {x: 0.9666666, y: 0.35555556}
+  m_AnchoredPosition: {x: 0.17689896, y: 0.83249664}
+  m_SizeDelta: {x: 0.09319997, y: -0.9349}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7553270965548282928
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5045841842879303489}
+  m_CullTransparentMesh: 1
+--- !u!114 &5048066450159293702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5045841842879303489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: <sprite name="Turn">1
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: f2921572f30bae248b5f9fc57444d5a8, type: 2}
+  m_sharedMaterial: {fileID: -5287552477783478505, guid: f2921572f30bae248b5f9fc57444d5a8,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 21.55
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 10
+  m_fontSizeMax: 32
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3512309186563616715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5045841842879303489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 494b3b58269bff34eb32fc139bff0da5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textFormat: '{0}{1}'
+--- !u!1001 &4045879434790424052
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[0].graphic
+      value: 
+      objectReference: {fileID: 1382345828906030163}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[1].graphic
+      value: 
+      objectReference: {fileID: 8836036307217071538}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[2].graphic
+      value: 
+      objectReference: {fileID: 344004266197907070}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[3].graphic
+      value: 
+      objectReference: {fileID: 8368006627651619462}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[4].graphic
+      value: 
+      objectReference: {fileID: 4970218582655063893}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[5].graphic
+      value: 
+      objectReference: {fileID: 4970218582655063893}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[6].graphic
+      value: 
+      objectReference: {fileID: 4970218582655063893}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[0].colorMult.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[0].colorMult.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[0].colorMult.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[1].colorMult.a
+      value: 0.5019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[1].colorMult.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[1].colorMult.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[1].colorMult.r
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[2].colorMult.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[2].colorMult.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[2].colorMult.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[2].colorMult.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[3].colorMult.a
+      value: 0.1254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[4].colorMult.a
+      value: 0.5019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[5].colorMult.a
+      value: 0.5019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[5].colorMult.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[5].colorMult.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[5].colorMult.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[6].colorMult.a
+      value: 0.5019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[6].colorMult.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[6].colorMult.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: graphics.Array.data[6].colorMult.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.2264151
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.2264151
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.2264151
+      objectReference: {fileID: 0}
+    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      insertIndex: 5
+      addedObject: {fileID: 9109684206142322495}
+    - targetCorrespondingSourceObject: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2701963088895337268}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1267530080514013113}
+  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+--- !u!114 &344004266197907070 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1275402629617245345 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1267530080514013113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275402629617245345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4176271842406729027}
+  isWorldSpace: 0
+  deselectOnPointerExit: 0
+  hoverAudio: {fileID: 0}
+  selectAudio: {fileID: 0}
+  submitAudio: {fileID: 0}
+  onSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  onDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  onSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  onPointerEnter:
+    m_PersistentCalls:
+      m_Calls: []
+  onPointerExit:
+    m_PersistentCalls:
+      m_Calls: []
+  icon: {fileID: 6588793765856302306}
+  glow: {fileID: 4970218582655063893}
+  fillImage: {fileID: 8345162756728015001}
+  statusText: {fileID: 3512309186563616715}
+  softGlow: {fileID: 8368006627651619462}
+  graphicGroup: {fileID: 4176271842406729027}
+--- !u!114 &1382345828906030163 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4176271842406729027 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275402629617245345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &4836416610268862496 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4970218582655063893 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6588793765856302306 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8368006627651619462 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8836036307217071538 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4808210373949616198, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4045879434790424052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UI/HUD/ActionMenu/SkillButton.prefab.meta
+++ b/Assets/Prefabs/UI/HUD/ActionMenu/SkillButton.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16e53d709742d4d3f8427c63f7c278b4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/Screens/CharacterManagementScreen/CharacterManagementScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/CharacterManagementScreen/CharacterManagementScreen.prefab
@@ -6586,6 +6586,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   applyBackgroundBlur: 1
+  m_OpenSound: {fileID: 0}
+  m_CloseSound: {fileID: 0}
   m_CharacterOverviewDisplay: {fileID: 129338328059288083}
   m_ReclassPanel: {fileID: 4639562406611449324}
   m_WeaponsOverviewDisplay: {fileID: 6166599531795910420}
@@ -7562,20 +7564,20 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3912695372592468516}
-  - {fileID: 49389768923156617}
-  - {fileID: 3946745784436345491}
-  - {fileID: 2488300962377666809}
-  - {fileID: 1401799078309300910}
-  - {fileID: 1730602168894831094}
-  - {fileID: 7033014283047898287}
-  - {fileID: 8691689778863845717}
-  - {fileID: 3533787622132687887}
-  - {fileID: 8926439502129465116}
-  - {fileID: 8146413080075420832}
-  - {fileID: 7990899000645471809}
-  - {fileID: 2552953306153774793}
-  - {fileID: 1637524823550857075}
+  - {fileID: 1038491339329478608}
+  - {fileID: 4074260485531884925}
+  - {fileID: 1071981547334436711}
+  - {fileID: 1922440428564864269}
+  - {fileID: 3121532466551408474}
+  - {fileID: 2315286062131508226}
+  - {fileID: 6467046824429240667}
+  - {fileID: 4664264824818990241}
+  - {fileID: 661836689523206651}
+  - {fileID: 4883252772474768104}
+  - {fileID: 5271470373588699476}
+  - {fileID: 6251200402247812021}
+  - {fileID: 1965874467289277245}
+  - {fileID: 3358684553167225479}
   m_Father: {fileID: 2137004696954710952}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7652,33 +7654,33 @@ MonoBehaviour:
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   graphics:
-  - graphic: {fileID: 2512534734273726219}
+  - graphic: {fileID: 1944298226644060927}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 1458472533999420838}
+  - graphic: {fileID: 3177378469324441682}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 2474541972482580412}
+  - graphic: {fileID: 1905743066252415560}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 3898646387558942166}
+  - graphic: {fileID: 1026574232134502434}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 569369335200456577}
+  - graphic: {fileID: 4594541935852671605}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 907100604117560537}
+  - graphic: {fileID: 3797505189037334829}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 8433192110933842304}
+  - graphic: {fileID: 5561222489782834292}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 7786138251832960122}
+  - graphic: {fileID: 6064152510332430734}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 2709046773651026208}
+  - graphic: {fileID: 2143060617896852692}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 8031021906611540531}
+  - graphic: {fileID: 6293272742247260103}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 7322608049988489615}
+  - graphic: {fileID: 6753984169644596347}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 8824696803631324014}
+  - graphic: {fileID: 4778960306426975898}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 4034969286525287398}
+  - graphic: {fileID: 1142452886497572370}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 156313822056225372}
+  - graphic: {fileID: 4183438880564369320}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &6092773384333331705
 GameObject:
@@ -8812,20 +8814,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   activeSkillButtons:
-  - {fileID: 8778542738750234452}
-  - {fileID: 5706199341527375353}
-  - {fileID: 8744479521444710371}
-  - {fileID: 7860805690752900489}
-  - {fileID: 6695508491263674334}
-  - {fileID: 6312740641722184838}
-  - {fileID: 3316127689595355615}
-  - {fileID: 3963198903316659237}
-  - {fileID: 9121338133737023871}
-  - {fileID: 3782492368935815788}
-  - {fileID: 4508901622059321808}
-  - {fileID: 2412356993416545073}
-  - {fileID: 7850583577024455609}
-  - {fileID: 6423999543772742147}
+  - {fileID: 3646149980403333125}
+  - {fileID: 322678193531697832}
+  - {fileID: 3607591940735230130}
+  - {fileID: 2764415406344256216}
+  - {fileID: 1702683320226422927}
+  - {fileID: 2076511410089858007}
+  - {fileID: 7300155340025046670}
+  - {fileID: 8955971278894668660}
+  - {fileID: 3881993745132457518}
+  - {fileID: 9165952026897395005}
+  - {fileID: 8491759371249872513}
+  - {fileID: 7651745429808473184}
+  - {fileID: 2862314784869106920}
+  - {fileID: 1327644375079888210}
   passiveSkillButtons: []
   skillHeaderText: {fileID: 1987451584188479375}
   skillDescriptionText: {fileID: 653133449040180526}
@@ -12546,245 +12548,278 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (13)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &156313822056225372 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &1327644375079888210 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 286988349380907755}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3358684553167225479 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 286988349380907755}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4183438880564369320 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 286988349380907755}
   m_PrefabAsset: {fileID: 0}
@@ -12792,24 +12827,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &1637524823550857075 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 286988349380907755}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6423999543772742147 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 286988349380907755}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &447561229376739126
@@ -12820,245 +12837,278 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &569369335200456577 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &1702683320226422927 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 447561229376739126}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3121532466551408474 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 447561229376739126}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4594541935852671605 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 447561229376739126}
   m_PrefabAsset: {fileID: 0}
@@ -13066,24 +13116,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &1401799078309300910 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 447561229376739126}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6695508491263674334 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 447561229376739126}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &761159339338418902
@@ -13547,245 +13579,278 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &907100604117560537 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &2076511410089858007 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 956570461852623982}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &2315286062131508226 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 956570461852623982}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3797505189037334829 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 956570461852623982}
   m_PrefabAsset: {fileID: 0}
@@ -13793,24 +13858,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &1730602168894831094 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 956570461852623982}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6312740641722184838 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 956570461852623982}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1023132138473398217
@@ -15018,251 +15065,272 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!224 &49389768923156617 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &322678193531697832 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 1580000403860245777}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1458472533999420838 stripped
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3177378469324441682 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 1580000403860245777}
   m_PrefabAsset: {fileID: 0}
@@ -15272,18 +15340,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5706199341527375353 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!224 &4074260485531884925 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 1580000403860245777}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1814815013911427746
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16841,245 +16903,266 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &2512534734273726219 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &1038491339329478608 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2526116912599142332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1944298226644060927 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2526116912599142332}
   m_PrefabAsset: {fileID: 0}
@@ -17089,22 +17172,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3912695372592468516 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 2526116912599142332}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8778542738750234452 stripped
+--- !u!114 &3646149980403333125 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2526116912599142332}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &2560180002687358731
@@ -17115,245 +17192,266 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &2474541972482580412 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &1071981547334436711 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2560180002687358731}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1905743066252415560 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2560180002687358731}
   m_PrefabAsset: {fileID: 0}
@@ -17363,22 +17461,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3946745784436345491 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 2560180002687358731}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8744479521444710371 stripped
+--- !u!114 &3607591940735230130 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2560180002687358731}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &2614541181563992471
@@ -17389,245 +17481,266 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (8)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &2709046773651026208 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &661836689523206651 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2614541181563992471}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2143060617896852692 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2614541181563992471}
   m_PrefabAsset: {fileID: 0}
@@ -17637,22 +17750,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3533787622132687887 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 2614541181563992471}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &9121338133737023871 stripped
+--- !u!114 &3881993745132457518 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 2614541181563992471}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &2731801149373029720
@@ -19069,32 +19176,32 @@ PrefabInstance:
     - target: {fileID: 5139437603316082348, guid: a5e5e6c40a38f4eef9f3f61b1156f815,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5139437603316082348, guid: a5e5e6c40a38f4eef9f3f61b1156f815,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5139437603316082348, guid: a5e5e6c40a38f4eef9f3f61b1156f815,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 145.84
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5139437603316082348, guid: a5e5e6c40a38f4eef9f3f61b1156f815,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 48.53
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5139437603316082348, guid: a5e5e6c40a38f4eef9f3f61b1156f815,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 75
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5139437603316082348, guid: a5e5e6c40a38f4eef9f3f61b1156f815,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -25
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -19127,251 +19234,260 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (12)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!224 &2552953306153774793 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 3904576646489846609}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &4034969286525287398 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &1142452886497572370 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 3904576646489846609}
   m_PrefabAsset: {fileID: 0}
@@ -19381,16 +19497,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &7850583577024455609 stripped
+--- !u!224 &1965874467289277245 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3904576646489846609}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2862314784869106920 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 3904576646489846609}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &4020033099716676961
@@ -19401,251 +19523,260 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!224 &2488300962377666809 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 4020033099716676961}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3898646387558942166 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &1026574232134502434 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 4020033099716676961}
   m_PrefabAsset: {fileID: 0}
@@ -19655,16 +19786,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &7860805690752900489 stripped
+--- !u!224 &1922440428564864269 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 4020033099716676961}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2764415406344256216 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 4020033099716676961}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &4089354107806381317
@@ -23418,257 +23555,266 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (10)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &4508901622059321808 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &5271470373588699476 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7228244194691225912}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7322608049988489615 stripped
+--- !u!114 &6753984169644596347 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7228244194691225912}
   m_PrefabAsset: {fileID: 0}
@@ -23678,12 +23824,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8146413080075420832 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!114 &8491759371249872513 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7228244194691225912}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7314602124357086226
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25298,257 +25450,266 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &3963198903316659237 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &4664264824818990241 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7916531587770412237}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7786138251832960122 stripped
+--- !u!114 &6064152510332430734 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7916531587770412237}
   m_PrefabAsset: {fileID: 0}
@@ -25558,12 +25719,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8691689778863845717 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!114 &8955971278894668660 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7916531587770412237}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7972263226380737156
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25572,257 +25739,266 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (9)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &3782492368935815788 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &4883252772474768104 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7972263226380737156}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8031021906611540531 stripped
+--- !u!114 &6293272742247260103 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7972263226380737156}
   m_PrefabAsset: {fileID: 0}
@@ -25832,12 +26008,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8926439502129465116 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!114 &9165952026897395005 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7972263226380737156}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7983890064503358444
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26174,263 +26356,260 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &3316127689595355615 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &5561222489782834292 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8419610890318762295}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &7033014283047898287 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8419610890318762295}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8433192110933842304 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 8419610890318762295}
   m_PrefabAsset: {fileID: 0}
@@ -26438,6 +26617,24 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &6467046824429240667 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8419610890318762295}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7300155340025046670 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8419610890318762295}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &8910193780529501145
@@ -26448,263 +26645,260 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6787134863844155864}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.8086035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48113197
+      objectReference: {fileID: 0}
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (11)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48113197
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.8086035
-      objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &2412356993416545073 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!114 &4778960306426975898 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8910193780529501145}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &7990899000645471809 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8910193780529501145}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8824696803631324014 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 8910193780529501145}
   m_PrefabAsset: {fileID: 0}
@@ -26712,5 +26906,23 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &6251200402247812021 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8910193780529501145}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7651745429808473184 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8910193780529501145}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UI/Screens/InspectScreen/InspectScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/InspectScreen/InspectScreen.prefab
@@ -450,20 +450,20 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2082914939857379544}
-  - {fileID: 7246228421209836838}
-  - {fileID: 8295867775007665491}
-  - {fileID: 8343936455145195793}
-  - {fileID: 5371369180334270807}
-  - {fileID: 4658054946158969447}
-  - {fileID: 5000108495295311663}
-  - {fileID: 8142540671087159391}
-  - {fileID: 4782307878685475409}
-  - {fileID: 6754173454079635719}
-  - {fileID: 1422958094640739204}
-  - {fileID: 4584017382270247274}
-  - {fileID: 1673529887755448433}
-  - {fileID: 2175747403991588011}
+  - {fileID: 2652015392975777068}
+  - {fileID: 6677184254095425746}
+  - {fileID: 5405742463871410343}
+  - {fileID: 5471385465156355301}
+  - {fileID: 8263883384492909731}
+  - {fileID: 8683333310399860627}
+  - {fileID: 9026952839032775387}
+  - {fileID: 5270834931200681387}
+  - {fileID: 8825914274961706917}
+  - {fileID: 7322427553358544115}
+  - {fileID: 3141970139368275568}
+  - {fileID: 556311571720236190}
+  - {fileID: 3394671197933567365}
+  - {fileID: 2743843724891541855}
   m_Father: {fileID: 2664280198020777771}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -512,7 +512,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1988119833628146459}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
@@ -522,33 +522,33 @@ MonoBehaviour:
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   graphics:
-  - graphic: {fileID: 611080711868954103}
+  - graphic: {fileID: 3485547807651624963}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 8078675885186242569}
+  - graphic: {fileID: 5204156771533821437}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 7472080330882955388}
+  - graphic: {fileID: 6888238657120761224}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 7447092645808806974}
+  - graphic: {fileID: 6880579556607414730}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 6780188475775335544}
+  - graphic: {fileID: 7367265112462520716}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 6068111190201571144}
+  - graphic: {fileID: 7787738686010186428}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 5904512260918376960}
+  - graphic: {fileID: 7625952576450050036}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 7319162105550421360}
+  - graphic: {fileID: 6752930766741106820}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 6254608302708004734}
+  - graphic: {fileID: 7991933256371231370}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 5271844111854150696}
+  - graphic: {fileID: 8146030554541779420}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 517248101771437739}
+  - graphic: {fileID: 4542016016110660447}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 3102783557335528517}
+  - graphic: {fileID: 1381079909284575665}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 264423894657443166}
+  - graphic: {fileID: 4291567371527874730}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
-  - graphic: {fileID: 766509194384935300}
+  - graphic: {fileID: 3640854522472907888}
     colorMult: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &2030038067608626528
 GameObject:
@@ -2755,6 +2755,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   applyBackgroundBlur: 1
+  m_OpenSound: {fileID: 0}
+  m_CloseSound: {fileID: 0}
   unitDisplay: {fileID: 5168067446080036174}
   skillDisplay: {fileID: 8501343545371977867}
 --- !u!95 &7134281774414870633
@@ -3707,20 +3709,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   activeSkillButtons:
-  - {fileID: 6014286479683431848}
-  - {fileID: 3103208779114070102}
-  - {fileID: 4377461881918169123}
-  - {fileID: 4347262634255844449}
-  - {fileID: 366452269357769767}
-  - {fileID: 1097670914238320407}
-  - {fileID: 791786384280511071}
-  - {fileID: 4512347562470581551}
-  - {fileID: 991110809593777953}
-  - {fileID: 1307360362104929399}
-  - {fileID: 6638399803693301492}
-  - {fileID: 8071218195695250458}
-  - {fileID: 6387963798133882113}
-  - {fileID: 5885860661642072539}
+  - {fileID: 1746576122612615929}
+  - {fileID: 6943094852976502535}
+  - {fileID: 8644028818031216498}
+  - {fileID: 8583447884560606000}
+  - {fileID: 5647507813489083254}
+  - {fileID: 4931909895944546374}
+  - {fileID: 4735220064711722254}
+  - {fileID: 8490701716123976318}
+  - {fileID: 5083224831140636784}
+  - {fileID: 6444283110070065958}
+  - {fileID: 1687241798191110565}
+  - {fileID: 4271846926223379275}
+  - {fileID: 1435671022503533136}
+  - {fileID: 1937914655966574218}
   passiveSkillButtons: []
   skillHeaderText: {fileID: 3149543858616792388}
   skillDescriptionText: {fileID: 1979272110148590517}
@@ -4101,302 +4103,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (12)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 3204087904866081074}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 2295662923184205411}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &264423894657443166 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 178926637844131305}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3165281579914198204}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &1673529887755448433 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 178926637844131305}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &3165281579914198204 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &1425546767413457224 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 178926637844131305}
   m_PrefabAsset: {fileID: 0}
@@ -4406,7 +4410,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3165281579914198204}
+  m_GameObject: {fileID: 1425546767413457224}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -4420,9 +4424,39 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!1 &6337652452291620711 stripped
+--- !u!114 &1435671022503533136 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 178926637844131305}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425546767413457224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3394671197933567365 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 178926637844131305}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4291567371527874730 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 178926637844131305}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425546767413457224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8058633785673278099 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 178926637844131305}
   m_PrefabAsset: {fileID: 0}
@@ -4432,7 +4466,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6337652452291620711}
+  m_GameObject: {fileID: 8058633785673278099}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -4440,18 +4474,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &6387963798133882113 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 178926637844131305}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3165281579914198204}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &347695389754616694
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4733,302 +4755,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (10)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1726743516283157367}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 8366352052158941185}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &517248101771437739 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 503667162476949020}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3416992531515522889}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &1422958094640739204 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 503667162476949020}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &3416992531515522889 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &1679351671279907517 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 503667162476949020}
   m_PrefabAsset: {fileID: 0}
@@ -5038,7 +5062,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3416992531515522889}
+  m_GameObject: {fileID: 1679351671279907517}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -5052,9 +5076,39 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!1 &6013733881310866578 stripped
+--- !u!114 &1687241798191110565 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 503667162476949020}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1679351671279907517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3141970139368275568 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 503667162476949020}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4542016016110660447 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 503667162476949020}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1679351671279907517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7732903703811596646 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 503667162476949020}
   m_PrefabAsset: {fileID: 0}
@@ -5064,7 +5118,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6013733881310866578}
+  m_GameObject: {fileID: 7732903703811596646}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -5072,18 +5126,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &6638399803693301492 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 503667162476949020}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3416992531515522889}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &696437668760386880
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5092,302 +5134,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 5445088910736379506}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 4272851152944173049}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &611080711868954103 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 696437668760386880}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2322947396360432661}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &2082914939857379544 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 696437668760386880}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2322947396360432661 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &1736451779610452449 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 696437668760386880}
   m_PrefabAsset: {fileID: 0}
@@ -5397,7 +5441,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2322947396360432661}
+  m_GameObject: {fileID: 1736451779610452449}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -5411,21 +5455,39 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &6014286479683431848 stripped
+--- !u!114 &1746576122612615929 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 696437668760386880}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2322947396360432661}
+  m_GameObject: {fileID: 1736451779610452449}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6638956595593985998 stripped
+--- !u!224 &2652015392975777068 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 696437668760386880}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3485547807651624963 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 696437668760386880}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1736451779610452449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7207894868597699130 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 696437668760386880}
   m_PrefabAsset: {fileID: 0}
@@ -5435,7 +5497,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6638956595593985998}
+  m_GameObject: {fileID: 7207894868597699130}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -5451,302 +5513,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (13)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1236452416566868853}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 4509405187644936039}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &766509194384935300 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 825268108150292787}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2514428057684758630}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &2175747403991588011 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 825268108150292787}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2514428057684758630 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &1927772740097318290 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 825268108150292787}
   m_PrefabAsset: {fileID: 0}
@@ -5756,7 +5820,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2514428057684758630}
+  m_GameObject: {fileID: 1927772740097318290}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -5770,21 +5834,39 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &5885860661642072539 stripped
+--- !u!114 &1937914655966574218 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 825268108150292787}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2514428057684758630}
+  m_GameObject: {fileID: 1927772740097318290}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6844206442119267261 stripped
+--- !u!224 &2743843724891541855 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 825268108150292787}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3640854522472907888 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 825268108150292787}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1927772740097318290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7412459445571571273 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 825268108150292787}
   m_PrefabAsset: {fileID: 0}
@@ -5794,7 +5876,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6844206442119267261}
+  m_GameObject: {fileID: 7412459445571571273}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -6122,284 +6204,334 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (11)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 8403634220235470507}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 3008425648588315977}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &236852151091588519 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!224 &556311571720236190 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3089343729791368434}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1381079909284575665 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3089343729791368434}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4281988859264507987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4271846926223379275 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3089343729791368434}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4281988859264507987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4281988859264507987 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 3089343729791368434}
   m_PrefabAsset: {fileID: 0}
@@ -6409,7 +6541,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236852151091588519}
+  m_GameObject: {fileID: 4281988859264507987}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -6423,39 +6555,9 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &3102783557335528517 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 3089343729791368434}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236852151091588519}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &4584017382270247274 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 3089343729791368434}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8071218195695250458 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 3089343729791368434}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 236852151091588519}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &9176080147302792828 stripped
+--- !u!1 &5148218753707864968 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 3089343729791368434}
   m_PrefabAsset: {fileID: 0}
@@ -6465,7 +6567,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9176080147302792828}
+  m_GameObject: {fileID: 5148218753707864968}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -6793,296 +6895,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (9)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 7610008852154611443}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 6106415909484080299}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &1307360362104929399 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 5258404172594572447}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7020936703619431882}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &2121735541892984337 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &2689830759592092645 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 5258404172594572447}
   m_PrefabAsset: {fileID: 0}
@@ -7092,7 +7202,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2121735541892984337}
+  m_GameObject: {fileID: 2689830759592092645}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -7100,27 +7210,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &5271844111854150696 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 5258404172594572447}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7020936703619431882}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &6754173454079635719 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 5258404172594572447}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7020936703619431882 stripped
+--- !u!1 &6434158784641314878 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 5258404172594572447}
   m_PrefabAsset: {fileID: 0}
@@ -7130,7 +7222,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7020936703619431882}
+  m_GameObject: {fileID: 6434158784641314878}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -7144,6 +7236,36 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &6444283110070065958 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5258404172594572447}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6434158784641314878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &7322427553358544115 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5258404172594572447}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8146030554541779420 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5258404172594572447}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6434158784641314878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &5716387797071551284
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7449,284 +7571,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 6175539561619262437}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 2719985295608510914}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &408063863614697529 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &4435027506513362381 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 5774118762426479287}
   m_PrefabAsset: {fileID: 0}
@@ -7736,7 +7878,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 408063863614697529}
+  m_GameObject: {fileID: 4435027506513362381}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -7744,39 +7886,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &791786384280511071 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 5774118762426479287}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8770532040346674146}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &5000108495295311663 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 5774118762426479287}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5904512260918376960 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 5774118762426479287}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8770532040346674146}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &8770532040346674146 stripped
+--- !u!1 &4725095715812306454 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 5774118762426479287}
   m_PrefabAsset: {fileID: 0}
@@ -7786,7 +7898,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8770532040346674146}
+  m_GameObject: {fileID: 4725095715812306454}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -7800,6 +7912,36 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &4735220064711722254 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5774118762426479287}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4725095715812306454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7625952576450050036 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5774118762426479287}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4725095715812306454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &9026952839032775387 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5774118762426479287}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6064330256624850910
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7964,284 +8106,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 4944010071850068465}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 3950552401613248509}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &31230012914834801 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &4056382485219725445 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6189777743017336831}
   m_PrefabAsset: {fileID: 0}
@@ -8251,7 +8413,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 31230012914834801}
+  m_GameObject: {fileID: 4056382485219725445}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -8259,39 +8421,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &1097670914238320407 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6189777743017336831}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8966798834428038826}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &4658054946158969447 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6189777743017336831}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6068111190201571144 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6189777743017336831}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8966798834428038826}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &8966798834428038826 stripped
+--- !u!1 &4924019754546856798 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6189777743017336831}
   m_PrefabAsset: {fileID: 0}
@@ -8301,7 +8433,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8966798834428038826}
+  m_GameObject: {fileID: 4924019754546856798}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -8315,6 +8447,36 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &4931909895944546374 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6189777743017336831}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4924019754546856798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7787738686010186428 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6189777743017336831}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4924019754546856798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8683333310399860627 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6189777743017336831}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6276916072104714185
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8323,284 +8485,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (8)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 2846547188193290841}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 8636838243150617690}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &185883911518788935 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &4229369909126385843 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6276916072104714185}
   m_PrefabAsset: {fileID: 0}
@@ -8610,7 +8792,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 185883911518788935}
+  m_GameObject: {fileID: 4229369909126385843}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -8618,39 +8800,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &991110809593777953 stripped
+--- !u!114 &5083224831140636784 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6276916072104714185}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9118364204870356636}
+  m_GameObject: {fileID: 5093349103267644264}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &4782307878685475409 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6276916072104714185}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6254608302708004734 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6276916072104714185}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9118364204870356636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &9118364204870356636 stripped
+--- !u!1 &5093349103267644264 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6276916072104714185}
   m_PrefabAsset: {fileID: 0}
@@ -8660,7 +8824,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9118364204870356636}
+  m_GameObject: {fileID: 5093349103267644264}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -8674,6 +8838,24 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &7991933256371231370 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6276916072104714185}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5093349103267644264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8825914274961706917 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6276916072104714185}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6583385133702145204
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8968,296 +9150,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1194248903604426395}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 679950509407209226}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!114 &366452269357769767 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6901996824923108559}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8529302628460979610}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &738766315633653313 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &3631442695607810997 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6901996824923108559}
   m_PrefabAsset: {fileID: 0}
@@ -9267,7 +9457,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 738766315633653313}
+  m_GameObject: {fileID: 3631442695607810997}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -9275,27 +9465,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!224 &5371369180334270807 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6901996824923108559}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6780188475775335544 stripped
+--- !u!114 &5647507813489083254 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6901996824923108559}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8529302628460979610}
+  m_GameObject: {fileID: 5655380268765489262}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &8529302628460979610 stripped
+--- !u!1 &5655380268765489262 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 6901996824923108559}
   m_PrefabAsset: {fileID: 0}
@@ -9305,7 +9489,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8529302628460979610}
+  m_GameObject: {fileID: 5655380268765489262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -9319,6 +9503,24 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &7367265112462520716 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6901996824923108559}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5655380268765489262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8263883384492909731 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6901996824923108559}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7224376188049192391
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9327,284 +9529,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 5880251776027795232}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 341981671212697144}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &3587770600279652169 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &715944466019515069 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7224376188049192391}
   m_PrefabAsset: {fileID: 0}
@@ -9614,7 +9836,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3587770600279652169}
+  m_GameObject: {fileID: 715944466019515069}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -9622,21 +9844,39 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &4512347562470581551 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!224 &5270834931200681387 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7224376188049192391}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5608346966395511954}
+--- !u!114 &6752930766741106820 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7224376188049192391}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8498574190727211366}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5608346966395511954 stripped
+--- !u!114 &8490701716123976318 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7224376188049192391}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8498574190727211366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8498574190727211366 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7224376188049192391}
   m_PrefabAsset: {fileID: 0}
@@ -9646,7 +9886,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5608346966395511954}
+  m_GameObject: {fileID: 8498574190727211366}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -9660,24 +9900,6 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &7319162105550421360 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7224376188049192391}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5608346966395511954}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &8142540671087159391 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7224376188049192391}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7377715931550937291
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9686,284 +9908,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 5483317303280146819}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 9175817606756091924}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &3740969613243003461 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &850971293554376625 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7377715931550937291}
   m_PrefabAsset: {fileID: 0}
@@ -9973,7 +10215,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3740969613243003461}
+  m_GameObject: {fileID: 850971293554376625}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -9981,21 +10223,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &4377461881918169123 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!224 &5405742463871410343 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7377715931550937291}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5761251310238687646}
+--- !u!114 &6888238657120761224 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7377715931550937291}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8633904483475795050}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5761251310238687646 stripped
+--- !u!1 &8633904483475795050 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7377715931550937291}
   m_PrefabAsset: {fileID: 0}
@@ -10005,7 +10253,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5761251310238687646}
+  m_GameObject: {fileID: 8633904483475795050}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -10019,24 +10267,18 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &7472080330882955388 stripped
+--- !u!114 &8644028818031216498 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7377715931550937291}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5761251310238687646}
+  m_GameObject: {fileID: 8633904483475795050}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8295867775007665491 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7377715931550937291}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7388616690528474249
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10045,284 +10287,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 7433610315047467093}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1508349346653862236}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &3675449927079335431 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &802779642228464627 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7388616690528474249}
   m_PrefabAsset: {fileID: 0}
@@ -10332,7 +10594,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3675449927079335431}
+  m_GameObject: {fileID: 802779642228464627}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -10340,21 +10602,39 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &4347262634255844449 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+--- !u!224 &5471385465156355301 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7388616690528474249}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5701374317752370652}
+--- !u!114 &6880579556607414730 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7388616690528474249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8591320341447936040}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5701374317752370652 stripped
+--- !u!114 &8583447884560606000 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7388616690528474249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8591320341447936040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8591320341447936040 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 7388616690528474249}
   m_PrefabAsset: {fileID: 0}
@@ -10364,7 +10644,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5701374317752370652}
+  m_GameObject: {fileID: 8591320341447936040}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -10378,24 +10658,6 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &7447092645808806974 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7388616690528474249}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5701374317752370652}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &8343936455145195793 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7388616690528474249}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7723759541062345288
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10560,284 +10822,304 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5646260612715138484}
     m_Modifications:
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 344004266197907070, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: defaultIconColor.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Name
+      value: SkillButton (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1382345828906030163, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2991634225281310325, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Name
-      value: ActionButton (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.80784315
       objectReference: {fileID: 0}
-    - target: {fileID: 3101517646396529063, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48235294
       objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4387631826459179914, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 5477776111246493554, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5969950141250234501, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.80784315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157839309508286742, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.48235294
-      objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8879900687553664468, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4836416610268862496, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.g
       value: 0.8086035
       objectReference: {fileID: 0}
-    - target: {fileID: 8997095426881395361, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - target: {fileID: 4970218582655063893, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       propertyPath: m_Color.r
       value: 0.48113197
       objectReference: {fileID: 0}
+    - target: {fileID: 5048066450159293702, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 6588793765856302306, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.80784315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8368006627651619462, guid: 16e53d709742d4d3f8427c63f7c278b4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.48235294
+      objectReference: {fileID: 0}
     m_RemovedComponents:
-    - {fileID: 3502169937962089665, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 630482954668601653, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_RemovedGameObjects:
-    - {fileID: 3508426346178780588, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
+    - {fileID: 618601479282249816, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 6970139691926520997}
-    - targetCorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+    - targetCorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1012393520391871605}
-  m_SourcePrefab: {fileID: 100100000, guid: 2b9da0b3337c59048804f16c3c4d8e9e, type: 3}
---- !u!1 &2613646445082661424 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 16e53d709742d4d3f8427c63f7c278b4, type: 3}
+--- !u!1 &2044722676636884932 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6163300918871999118, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 7903158115993489274, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 8200483312543273150}
   m_PrefabAsset: {fileID: 0}
@@ -10847,7 +11129,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2613646445082661424}
+  m_GameObject: {fileID: 2044722676636884932}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
@@ -10855,21 +11137,39 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
---- !u!114 &3103208779114070102 stripped
+--- !u!114 &5204156771533821437 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6547450930762010856, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 4176271842406729027, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 8200483312543273150}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6366684801260028395}
+  m_GameObject: {fileID: 6953236701854977055}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d4b75d9e4b5b4580e116741535306, type: 3}
+  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6366684801260028395 stripped
+--- !u!224 &6677184254095425746 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3271838381362483308, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8200483312543273150}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6943094852976502535 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1267530080514013113, guid: 16e53d709742d4d3f8427c63f7c278b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8200483312543273150}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6953236701854977055}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d3902067ffdf43089b80adc240844a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6953236701854977055 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2996857513679425877, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
+  m_CorrespondingSourceObject: {fileID: 1275402629617245345, guid: 16e53d709742d4d3f8427c63f7c278b4,
     type: 3}
   m_PrefabInstance: {fileID: 8200483312543273150}
   m_PrefabAsset: {fileID: 0}
@@ -10879,7 +11179,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6366684801260028395}
+  m_GameObject: {fileID: 6953236701854977055}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -10893,21 +11193,3 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!224 &7246228421209836838 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1531855288010038680, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8200483312543273150}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8078675885186242569 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 130816551294290103, guid: 2b9da0b3337c59048804f16c3c4d8e9e,
-    type: 3}
-  m_PrefabInstance: {fileID: 8200483312543273150}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6366684801260028395}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67bb6d00a894b3347b4f70f0794548bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UI/Screens/InspectScreen/PreviewScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/InspectScreen/PreviewScreen.prefab
@@ -209,11 +209,46 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 556311571720236190, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 556311571720236190, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 556311571720236190, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 556311571720236190, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 556311571720236190, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 556311571720236190, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 789896571956954474, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 857933479528215743, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1014714260503189984, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -249,6 +284,11 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1387017578865945239, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1422958094640739204, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -277,6 +317,16 @@ PrefabInstance:
     - target: {fileID: 1422958094640739204, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1441840868177872873, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1655324958914840543, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1673529887755448433, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -347,6 +397,11 @@ PrefabInstance:
     - target: {fileID: 2021573774747877912, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2078049228436122863, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2082914939857379544, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -434,12 +489,87 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2652015392975777068, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2652015392975777068, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2652015392975777068, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2652015392975777068, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2652015392975777068, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2652015392975777068, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2662594037663949083, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2671506681623048096, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2701190854634809579, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2708850251470933161, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743843724891541855, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743843724891541855, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743843724891541855, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743843724891541855, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743843724891541855, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743843724891541855, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2836217274303098343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
@@ -482,6 +612,36 @@ PrefabInstance:
     - target: {fileID: 3115505481608251724, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141970139368275568, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141970139368275568, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141970139368275568, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141970139368275568, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141970139368275568, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141970139368275568, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3181699994212092445, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -540,6 +700,41 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3376922019278408235, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3394671197933567365, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3394671197933567365, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3394671197933567365, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3394671197933567365, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3394671197933567365, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3394671197933567365, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3662446121054554270, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
@@ -694,6 +889,11 @@ PrefabInstance:
       propertyPath: textFormat
       value: '{0} / {1}'
       objectReference: {fileID: 0}
+    - target: {fileID: 4712396456413246921, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4782307878685475409, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -757,6 +957,11 @@ PrefabInstance:
     - target: {fileID: 5000108495295311663, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5035875224888309308, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5038773955102227119, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -892,6 +1097,41 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5218994327880866067, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5270834931200681387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5270834931200681387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5270834931200681387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5270834931200681387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5270834931200681387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5270834931200681387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5371369180334270807, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -918,6 +1158,71 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5371369180334270807, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5383025409773675872, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405742463871410343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405742463871410343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405742463871410343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405742463871410343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405742463871410343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405742463871410343, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5471385465156355301, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5471385465156355301, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5471385465156355301, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5471385465156355301, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5471385465156355301, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5471385465156355301, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -965,6 +1270,36 @@ PrefabInstance:
     - target: {fileID: 5900897906573535526, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6677184254095425746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6677184254095425746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6677184254095425746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6677184254095425746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6677184254095425746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6677184254095425746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6680285723641044257, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -1057,6 +1392,36 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7322427553358544115, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7322427553358544115, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7322427553358544115, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7322427553358544115, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7322427553358544115, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7322427553358544115, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7408900854572361875, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -1080,6 +1445,11 @@ PrefabInstance:
     - target: {fileID: 7408900854572361875, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7620629919887041746, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8090802872123643111, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -1120,6 +1490,36 @@ PrefabInstance:
     - target: {fileID: 8255521420437350548, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8263883384492909731, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8263883384492909731, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8263883384492909731, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8263883384492909731, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8263883384492909731, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8263883384492909731, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8294599161533495151, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
@@ -1237,9 +1637,99 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8683333310399860627, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683333310399860627, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683333310399860627, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683333310399860627, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683333310399860627, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683333310399860627, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8737003570482640957, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
         type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825914274961706917, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825914274961706917, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825914274961706917, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825914274961706917, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825914274961706917, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825914274961706917, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9026952839032775387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9026952839032775387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9026952839032775387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9026952839032775387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9026952839032775387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9026952839032775387, guid: 3055c3a9e28ced14ab1249d9fde2fedb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9063173454850014152, guid: 3055c3a9e28ced14ab1249d9fde2fedb,

--- a/Assets/Scripts/Base/UI/HUD/ActionButton.cs
+++ b/Assets/Scripts/Base/UI/HUD/ActionButton.cs
@@ -25,11 +25,5 @@ namespace Game.UI
         {
             glow.CrossFadeAlpha(active ? 1 : 0, 0.2f, false);
         }
-
-        public void SetActive(bool active)
-        {
-            interactable = active;
-            icon.color = active ? Color.red : Color.clear;
-        }
     }
 }

--- a/Assets/Scripts/Base/UI/HUD/ActionMenu.cs
+++ b/Assets/Scripts/Base/UI/HUD/ActionMenu.cs
@@ -23,7 +23,7 @@ namespace Game.UI
         private ActionButton leftScrollButton;
 
         [SerializeField]
-        private List<ActionButton> skillButtons = new();
+        private List<SkillButton> skillButtons = new();
 
         [SerializeField]
         private ActionButton rightScrollButton;
@@ -63,7 +63,7 @@ namespace Game.UI
                 if (availableSkills.Count == 0)
                 {
                     currentSkillPageIndex = 0;
-                    skillButtons.ForEach(x => x.SetActive(false));
+                    skillButtons.ForEach(x => x.SetState(SkillButtonState.EMPTY));
                     return;
                 }
 
@@ -80,13 +80,26 @@ namespace Game.UI
                     if (startIndex + i < availableSkills.Count)
                     {
                         var skill = availableSkills[startIndex + i];
+                        button.SkillSprite = skill.m_Icon;
 
-                        button.SetActive(true);
-                        button.icon.sprite = skill.m_Icon;
+                        if (!currentUnit.HasEnoughManaForSkill(skill))
+                        {
+                            button.SetFill(0f);
+                            button.statusText?.SetValue(skill.m_ConsumedMana, "<sprite name=\"Mana\" tint>");
+                            button.SetState(SkillButtonState.LOCKED);
+                        }
+                        else
+                        {
+                            button.SetFill(currentUnit.GetSkillCooldownProportion(skill));
+                            int cooldown = currentUnit.GetSkillCooldown(skill);
+                            button.statusText?.SetValue("<sprite name=\"Turn\" tint>", cooldown);
+                            button.SetState(cooldown > 0 ? SkillButtonState.LOCKED : SkillButtonState.NORMAL);
+                        }
                     }
                     else
                     {
-                        button.SetActive(false);
+                        button.SetFill(1f);
+                        button.SetState(SkillButtonState.EMPTY);
                     }
                 }
             }

--- a/Assets/Scripts/Base/UI/HUD/ActionMenu.meta
+++ b/Assets/Scripts/Base/UI/HUD/ActionMenu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d97c327e0b6ea4996a6555cb7951381f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Base/UI/HUD/ActionMenu/SkillButton.cs
+++ b/Assets/Scripts/Base/UI/HUD/ActionMenu/SkillButton.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.UI
+{
+    public enum SkillButtonState
+    {
+        EMPTY,
+        LOCKED,
+        NORMAL
+    }
+
+    public class SkillButton : ActionButton
+    {
+        public Color defaultIconColor = Color.red;
+        public Image fillImage;
+        public FormattedTextDisplay statusText;
+        public Image softGlow;
+        public GraphicGroup graphicGroup;
+
+        public Sprite SkillSprite {
+            set {
+                fillImage.sprite = value;
+                icon.sprite = value;
+            }
+        }
+
+        public void SetFill(float fill)
+        {
+            fillImage.fillAmount = fill;
+            softGlow.gameObject.SetActive(fill >= 1f);
+            graphicGroup.color = fill >= 1f ? defaultIconColor : Color.grey;
+        }
+
+        public void SetState(SkillButtonState skillButtonState)
+        {
+            interactable = skillButtonState != SkillButtonState.EMPTY;
+            icon.color = skillButtonState == SkillButtonState.EMPTY ? Color.clear : Color.gray;
+            fillImage.color = skillButtonState == SkillButtonState.EMPTY ? Color.clear : defaultIconColor;
+            statusText.gameObject.SetActive(skillButtonState == SkillButtonState.LOCKED);
+        }
+    }
+}

--- a/Assets/Scripts/Base/UI/HUD/ActionMenu/SkillButton.cs.meta
+++ b/Assets/Scripts/Base/UI/HUD/ActionMenu/SkillButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d3902067ffdf43089b80adc240844a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Base/UI/Screens/CharacterManagementScreen/SkillsAndWeaponPanel/SkillsOverviewDisplay.cs
+++ b/Assets/Scripts/Base/UI/Screens/CharacterManagementScreen/SkillsAndWeaponPanel/SkillsOverviewDisplay.cs
@@ -12,7 +12,7 @@ namespace Game.UI
         private CanvasGroup canvasGroup;
         
         [SerializeField]
-        private List<ActionButton> activeSkillButtons = new();
+        private List<SkillButton> activeSkillButtons = new();
         
         [SerializeField]
         private List<ActionButton> passiveSkillButtons = new();
@@ -88,8 +88,32 @@ namespace Game.UI
                 {
                     var skill = activeSkills[i];
 
-                    activeSkillButtons[i].gameObject.SetActive(true);
-                    activeSkillButtons[i].icon.sprite = skill.m_Icon;
+                    var button = activeSkillButtons[i];
+                    button.gameObject.SetActive(true);
+                    button.SkillSprite = skill.m_Icon;
+
+                    if (unit is Unit)
+                    {
+                        Unit castUnit = (Unit) unit;
+                        if (!castUnit.HasEnoughManaForSkill(skill))
+                        {
+                            button.SetFill(0f);
+                            button.statusText?.SetValue(skill.m_ConsumedMana, "<sprite name=\"Mana\" tint>");
+                            button.SetState(SkillButtonState.LOCKED);
+                        }
+                        else
+                        {
+                            button.SetFill(castUnit.GetSkillCooldownProportion(skill));
+                            int cooldown = castUnit.GetSkillCooldown(skill);
+                            button.statusText?.SetValue("<sprite name=\"Turn\" tint>", cooldown);
+                            button.SetState(cooldown > 0 ? SkillButtonState.LOCKED : SkillButtonState.NORMAL);
+                        }
+                    }
+                    else
+                    {
+                        button.SetFill(1f);
+                        button.SetState(SkillButtonState.NORMAL);
+                    }
                 }
                 else
                 {

--- a/Assets/Scripts/Battle/TurnManagement/PlayerTurnManager.cs
+++ b/Assets/Scripts/Battle/TurnManagement/PlayerTurnManager.cs
@@ -272,10 +272,20 @@ public class PlayerTurnManager : TurnManager
         return false;
     }
 
+    private bool CheckCooldownRequirement(Unit unit, ActiveSkillSO skill)
+    {
+        if (unit == null || skill == null) return true;
+        if (unit.CanPerformSkill(skill)) return true;
+
+        ToastNotificationManager.Instance.Show($"Remaining cooldown: {unit.GetSkillCooldown(skill)}", Color.red);
+        return false;
+    }
+
     private bool TryPerformSkill()
     {
         if (selectedTileData == null || selectedTileVisual == null) return false;
         if (!CheckSkillManaRequirement(m_CurrUnit, selectedSkill)) return false;
+        if (!CheckCooldownRequirement(m_CurrUnit, selectedSkill)) return false;
 
         if (m_MapLogic.CanPerformSkill(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType, true))
         {
@@ -450,7 +460,9 @@ public class PlayerTurnManager : TurnManager
                 }
                 else
                 {
-                    CheckSkillManaRequirement(m_CurrUnit, selectedSkill);
+                    bool manaReq = CheckSkillManaRequirement(m_CurrUnit, selectedSkill);
+                    if (manaReq)
+                        CheckCooldownRequirement(m_CurrUnit, selectedSkill);
                 }
                 break;
             case PlayerTurnState.SELECTING_MOVEMENT_SQUARE:

--- a/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillActionSO.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillActionSO.cs
@@ -163,6 +163,9 @@ public class EnemyActiveSkillActionSO : EnemyActionSO
         targetablePositions = new List<CoordPair>();
         targetablePositionsIgnoreOccupiedAndAdditionalConditions = new List<CoordPair>();
 
+        if (!enemyUnit.CanPerformSkill(m_ActiveSkill))
+            return false;
+
         if (m_ActiveSkill.m_ConsumedMana > enemyUnit.CurrentMana)
             return false;
 

--- a/Assets/Scripts/Battle/Units/EnemyUnit.cs
+++ b/Assets/Scripts/Battle/Units/EnemyUnit.cs
@@ -49,6 +49,7 @@ public class EnemyUnit : Unit
     {
         m_OrderedConditions = new();
         m_OrderedActions = new();
+        List<ActiveSkillSO> activeSkills = new();
         foreach (EnemyAction enemyAction in enemyActionSetSO.m_EnemyActions)
         {
             EnemyActionWrapper enemyActionWrapper = enemyAction.EnemyActionWrapper;
@@ -57,9 +58,15 @@ public class EnemyUnit : Unit
                 m_OrderedConditions.Add((condition, enemyActionWrapper));
             }
             m_OrderedActions.Add(enemyActionWrapper);
+
+            if (enemyAction.m_EnemyAction is EnemyActiveSkillActionSO)
+            {
+                activeSkills.Add(((EnemyActiveSkillActionSO) enemyAction.m_EnemyAction).m_ActiveSkill);
+            }
         }
         m_OrderedConditions.Sort((x, y) => y.Item1.m_Priority.CompareTo(x.Item1.m_Priority));
         m_OrderedActions.Sort((x, y) => y.m_Priority.CompareTo(x.m_Priority));
+        m_SkillCooldownTracker.SetSkills(activeSkills);
     }
 
     // can cache action

--- a/Assets/Scripts/Battle/Units/PlayerUnit.cs
+++ b/Assets/Scripts/Battle/Units/PlayerUnit.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 public class PlayerUnit : Unit
 {
@@ -18,6 +17,7 @@ public class PlayerUnit : Unit
         permanentTokens.AddRange(additionalPermanentTokens);
         permanentTokens.AddRange(characterBattleData.GetInflictedTokens(currMoralityPercentage));
         base.Initialise(characterBattleData.m_CurrStats, characterBattleData.m_BaseData.m_Race, characterBattleData.m_ClassSO, characterBattleData.m_BaseData.m_CharacterSprite, characterBattleData.GetUnitModelData(), characterBattleData.m_CurrEquippedWeapon, permanentTokens);
+        m_SkillCooldownTracker.SetSkills(characterBattleData.m_ClassSO.m_ActiveSkills);
     }
     #endregion
 

--- a/Assets/Scripts/Battle/Units/SkillCooldownTracker.cs
+++ b/Assets/Scripts/Battle/Units/SkillCooldownTracker.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class SkillCooldownTracker
+{
+    private readonly Dictionary<ActiveSkillSO, int> m_Cooldowns = new();
+
+    public void Tick()
+    {
+        IEnumerable<ActiveSkillSO> keys = m_Cooldowns.Keys.ToList();
+        foreach (ActiveSkillSO activeSkillSO in keys)
+        {
+            m_Cooldowns[activeSkillSO] = Mathf.Max(m_Cooldowns[activeSkillSO] - 1, 0);
+        }
+    }
+
+    public int GetCooldown(ActiveSkillSO activeSkillSO)
+    {
+        return m_Cooldowns.GetValueOrDefault(activeSkillSO, 0);
+    }
+
+    public bool CanUtiliseSkill(ActiveSkillSO activeSkillSO)
+    {
+        return GetCooldown(activeSkillSO) <= 0;
+    }
+
+    public float GetCooldownProportion(ActiveSkillSO activeSkillSO)
+    {
+        if (activeSkillSO.m_CooldownTurns <= 0)
+            return 1f;
+
+        return (float) (activeSkillSO.m_CooldownTurns - GetCooldown(activeSkillSO)) / activeSkillSO.m_CooldownTurns;
+    }
+
+    public void UtiliseSkill(ActiveSkillSO activeSkillSO)
+    {
+        if (m_Cooldowns.ContainsKey(activeSkillSO))
+        {
+            m_Cooldowns[activeSkillSO] = activeSkillSO.m_CooldownTurns + 1;
+            Debug.Log(activeSkillSO.m_CooldownTurns + 1);
+        }
+    }
+
+    public void SetSkills(IEnumerable<ActiveSkillSO> activeSkills)
+    {
+        m_Cooldowns.Clear();
+        foreach (ActiveSkillSO activeSkillSO in activeSkills)
+        {
+            if (activeSkillSO.m_CooldownTurns > 0)
+            {
+                m_Cooldowns.Add(activeSkillSO, 0);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Battle/Units/SkillCooldownTracker.cs.meta
+++ b/Assets/Scripts/Battle/Units/SkillCooldownTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4455d9b8f92334dc5a60f07bda8f3fed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/Units/Unit.cs
+++ b/Assets/Scripts/Battle/Units/Unit.cs
@@ -58,6 +58,8 @@ public abstract class Unit : MonoBehaviour, IHealth, ICanAttack, IFlatStatChange
 
     protected StatusManager m_StatusManager = new StatusManager();
     public IStatusManager StatusManager => m_StatusManager;
+
+    protected SkillCooldownTracker m_SkillCooldownTracker = new();
     #endregion
 
     #region Static Data
@@ -270,6 +272,7 @@ public abstract class Unit : MonoBehaviour, IHealth, ICanAttack, IFlatStatChange
     public void Tick()
     {
         m_StatusManager.Tick(this);
+        m_SkillCooldownTracker.Tick();
     }
     #endregion
 
@@ -539,6 +542,8 @@ public abstract class Unit : MonoBehaviour, IHealth, ICanAttack, IFlatStatChange
         GlobalEvents.Battle.CompleteAttackAnimationEvent += CompleteAttackAnimationEvent;
         GlobalEvents.Battle.AttackAnimationEvent?.Invoke(attackSO, this, targets.Select(x => (Unit) x).ToList());
 
+        m_SkillCooldownTracker.UtiliseSkill(attackSO);
+
         AnimationEventHandler.onSkillHit += OnSkillHit;
 
         void OnSkillHit()
@@ -629,6 +634,21 @@ public abstract class Unit : MonoBehaviour, IHealth, ICanAttack, IFlatStatChange
             GlobalEvents.Battle.CompleteAttackAnimationEvent -= CompleteAttackAnimationEvent;
             PostSkillEvent?.Invoke();
         }
+    }
+
+    public bool CanPerformSkill(ActiveSkillSO activeSkillSO)
+    {
+        return m_SkillCooldownTracker.CanUtiliseSkill(activeSkillSO);
+    }
+
+    public int GetSkillCooldown(ActiveSkillSO activeSkillSO)
+    {
+        return m_SkillCooldownTracker.GetCooldown(activeSkillSO);
+    }
+
+    public float GetSkillCooldownProportion(ActiveSkillSO activeSkillSO)
+    {
+        return m_SkillCooldownTracker.GetCooldownProportion(activeSkillSO);
     }
 
     public VoidEvent PostSkillEvent;

--- a/Assets/Scripts/Persistent Data/Active Skills/ActiveSkillSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/ActiveSkillSO.cs
@@ -35,6 +35,8 @@ public class ActiveSkillSO : ScriptableObject
     public SkillType m_SkillType;
     [Tooltip("Amount of mana to consume to utilise this skill. Leave as 0 if this does not consume mana")]
     public float m_ConsumedMana = 0f;
+    [Tooltip("Number of turns that must pass before the skill can be used again - set at 0 for no cooldown")]
+    public int m_CooldownTurns = 0;
 
     [Header("Effects")]
     [Tooltip("Determines what the skill does upon being activated")]
@@ -168,6 +170,11 @@ public class ActiveSkillSO : ScriptableObject
         if (m_ConsumedMana > 0)
         {
             builder.AppendLine($"Mana Cost: {m_ConsumedMana:F1}");
+        }
+
+        if (m_CooldownTurns > 0)
+        {
+            builder.AppendLine($"Cooldown: {m_CooldownTurns} <sprite name=\"Turn\" tint>");
         }
 
         var skillTypesSet = new HashSet<SkillEffectType>(m_SkillTypes);


### PR DESCRIPTION
* Add skill cooldowns to skill SO
  * If a skill has a skill cooldown of 2, the unit will be able to use the skill again on the third turn after initially using the skill
* Add skill cooldown as a check for player and enemy units
* Track skill cooldowns and tick them appropriately 
* Add skill buttons
  * Greyed out if skill cannot be performed (done in inspect screen and action menu)
    * If mana insufficient, indicate amount of mana required
    * If on cooldown, indicate turns remaining and fill icon
* Add cooldowns to skill description

TODO:
- honestly i still don't know why the icons are. so bright. they are not supposed to be so bright.