### PR TITLE
Add scene load window

### DIFF
--- a/Assets/Scripts/Helper/Tools/SceneLoad.meta
+++ b/Assets/Scripts/Helper/Tools/SceneLoad.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 950bd29e53b984bf3b96c567f5ad251e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Helper/Tools/SceneLoad/SceneLoadTool.cs
+++ b/Assets/Scripts/Helper/Tools/SceneLoad/SceneLoadTool.cs
@@ -1,0 +1,138 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+
+#if UNITY_EDITOR
+public class SceneLoadTool : EditorWindow
+{
+    private string m_MainMenuPath = "Assets/Scenes/MainMenuScene";
+    private string m_WorldMapPath = "Assets/Scenes/WorldMapScene";
+    private string m_LevelPath = "Assets/Scenes/Level{0}Scene";
+    private string m_BattlePath = "Assets/Scenes/BattleScene";
+
+    private string m_CurrentScenePath; 
+    private const string SCENE_PATH_FORMAT = "{0}.unity";
+
+    private int m_LevelNumber = 1;
+
+    [MenuItem("Window/Scene Load Tool")]
+    public static void ShowSceneLoadWindow()
+    {
+        SceneLoadTool wnd = GetWindow<SceneLoadTool>();
+        wnd.titleContent = new GUIContent("SceneLoadTool");
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.Label("Load Scenes");
+        m_MainMenuPath = EditorGUILayout.TextField("Main Menu Scene Path", m_MainMenuPath);
+        if (GUILayout.Button("Load Menu Scene"))
+        {
+            LoadScene(string.Format(SCENE_PATH_FORMAT, m_MainMenuPath));
+        }
+
+        GUILayout.Space(10f);
+        m_WorldMapPath = EditorGUILayout.TextField("World Map Scene Path", m_WorldMapPath);
+        if (GUILayout.Button("Load World Map Scene"))
+        {
+            LoadScene(string.Format(SCENE_PATH_FORMAT, m_WorldMapPath));
+        }
+
+        GUILayout.Space(10f);
+        m_LevelPath = EditorGUILayout.TextField("Level Scene Path", m_LevelPath);
+        m_LevelNumber = EditorGUILayout.IntField("Level Number", m_LevelNumber);
+        if (GUILayout.Button($"Load Level {m_LevelNumber} Scene"))
+        {
+            LoadScene(string.Format(SCENE_PATH_FORMAT, string.Format(m_LevelPath, m_LevelNumber)));
+        }
+
+        GUILayout.Space(10f);
+        m_BattlePath = EditorGUILayout.TextField("Battle Scene Path", m_BattlePath);
+        if (GUILayout.Button("Load Battle Scene"))
+        {
+            LoadScene(string.Format(SCENE_PATH_FORMAT, m_BattlePath));
+        }
+
+        GUILayout.Space(30f);
+        GUILayout.Label("Load Game");
+        if (GUILayout.Button("Load Game"))
+        {
+            m_CurrentScenePath = EditorSceneManager.GetActiveScene().path;
+            LoadScene(string.Format(SCENE_PATH_FORMAT, m_MainMenuPath), PlayScene);
+        }
+        if (GUILayout.Button("Stop - does normal editor stop"))
+        {
+            Stop();
+        }
+        if (GUILayout.Button("Stop at Previously Opened Scene"))
+        {
+            Stop(m_CurrentScenePath);
+        }
+        if (GUILayout.Button("Stop at Current Scene\nThis doesn't work super well with async scenes"))
+        {
+            StopAtCurrentScene();
+        }
+    }
+
+    private void LoadScene(string scenePath, VoidEvent postEvent = null)
+    {
+        if (EditorApplication.isPlaying)
+        {
+            Logger.LogEditor(this.GetType().Name, "Application is playing - Cancel scene action", LogLevel.ERROR);
+            return;
+        }
+
+        if (EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+        {
+            EditorSceneManager.OpenScene(scenePath);
+            postEvent?.Invoke();
+        }
+        else
+        {
+            Logger.LogEditor(this.GetType().Name, "Cancel scene action", LogLevel.LOG);
+        }
+    }
+
+    private void PlayScene()
+    {
+        EditorApplication.EnterPlaymode();
+    }
+
+    private void StopAtCurrentScene()
+    {
+        if (!EditorApplication.isPlaying)
+        {
+            Logger.LogEditor(this.GetType().Name, "Application is not playing - Cancel stop", LogLevel.WARNING);
+            return;
+        }
+
+        Stop(SceneManager.GetActiveScene().path);
+    }
+
+    private void Stop(string scenePathToReturnTo = null)
+    {
+        if (!EditorApplication.isPlaying)
+        {
+            Logger.LogEditor(this.GetType().Name, "Application is not playing - Cancel stop", LogLevel.WARNING);
+            return;
+        }
+
+        EditorApplication.playModeStateChanged += PostStop;
+        EditorApplication.ExitPlaymode();
+
+        void PostStop(PlayModeStateChange playModeStateChange)
+        {
+            if (playModeStateChange != PlayModeStateChange.EnteredEditMode)
+                return;
+
+            EditorApplication.playModeStateChanged -= PostStop;
+            if (!string.IsNullOrEmpty(scenePathToReturnTo))
+            {
+                LoadScene(scenePathToReturnTo);
+            }
+            m_CurrentScenePath = null;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Helper/Tools/SceneLoad/SceneLoadTool.cs.meta
+++ b/Assets/Scripts/Helper/Tools/SceneLoad/SceneLoadTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a379a1b612264ade9e48cb1a314eec5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Add scene load tool under Windows > Scene Load Tool
* Can be used to open any major scene, and start playing from main menu irregardless of current scene
  * Stopping options include stopping on previously open scene, and stopping on current scene (for async loaded scenes, it will go to the first scene to be loaded i.e. WorldMap)