### PR TITLE
Count visual distance across entire grid

### DIFF
--- a/Assets/Persistent Data/TargetSO/All Same Col.asset
+++ b/Assets/Persistent Data/TargetSO/All Same Col.asset
@@ -13,21 +13,21 @@ MonoBehaviour:
   m_Name: All Same Col
   m_EditorClassIdentifier: 
   m_TargetTiles:
-  - m_Row: 0
-    m_Col: -4
-  - m_Row: 0
-    m_Col: -3
-  - m_Row: 0
-    m_Col: -2
-  - m_Row: 0
-    m_Col: -1
-  - m_Row: 0
-    m_Col: 1
-  - m_Row: 0
-    m_Col: 2
-  - m_Row: 0
-    m_Col: 3
-  - m_Row: 0
-    m_Col: 4
+  - m_Row: -4
+    m_Col: 0
+  - m_Row: -3
+    m_Col: 0
+  - m_Row: -2
+    m_Col: 0
+  - m_Row: -1
+    m_Col: 0
+  - m_Row: 1
+    m_Col: 0
+  - m_Row: 2
+    m_Col: 0
+  - m_Row: 3
+    m_Col: 0
+  - m_Row: 4
+    m_Col: 0
   m_Description: Whole Column
   m_TargetRepSprite: {fileID: 21300000, guid: 20a7b11e821c5624dba2492e626d8b3d, type: 3}

--- a/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillActionSO.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillActionSO.cs
@@ -228,7 +228,7 @@ public class EnemyActiveSkillActionSO : EnemyActionSO
             for (int c = 0; c < MapData.NUM_COLS; ++c)
             {
                 CoordPair teleportTargetTile = new CoordPair(r, c);
-                if (mapLogic.IsValidTeleportTile(m_ActiveSkill, enemyUnit, finalTeleportedTile, teleportTargetTile, targetTeleportGrid) && m_TeleportTileConditions.All(x => x.IsConditionMet(enemyUnit, mapLogic, teleportTargetTile, finalTeleportedTile)))
+                if (mapLogic.IsValidTeleportTile(m_ActiveSkill, enemyUnit, finalTeleportedTile, teleportTargetTile, targetTeleportGrid) && m_TeleportTileConditions.All(x => x.IsConditionMet(enemyUnit, mapLogic, targetTeleportGrid, teleportTargetTile, finalTeleportedTile)))
                 {
                     possibleTeleportTargetTiles = possibleTeleportTargetTiles.Append(teleportTargetTile);
                 }

--- a/Assets/Scripts/Battle/Units/EnemyAI/Conditions/Definition/EnemyTeleportTileConditionSO.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Conditions/Definition/EnemyTeleportTileConditionSO.cs
@@ -2,5 +2,5 @@ using UnityEngine;
 
 public abstract class EnemyTeleportTileConditionSO : ScriptableObject
 {
-    public abstract bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, CoordPair teleportTargetTile, CoordPair initialTarget);
+    public abstract bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, GridType targetGridType, CoordPair teleportTargetTile, CoordPair initialTarget);
 }

--- a/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinAttackerRange.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinAttackerRange.cs
@@ -5,8 +5,8 @@ public class TeleportTargetTileWithinAttackerRange : EnemyTeleportTileConditionS
 {
     public RangeDefinition m_AllowedRange;
 
-    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, CoordPair teleportTargetTile, CoordPair initialTarget)
+    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, GridType targetGridType, CoordPair teleportTargetTile, CoordPair initialTarget)
     {
-        return m_AllowedRange.IsWithinRange(enemyUnit.CurrPosition, teleportTargetTile);
+        return m_AllowedRange.IsWithinRange(GridHelper.GetSameSide(enemyUnit.UnitAllegiance), targetGridType, enemyUnit.CurrPosition, teleportTargetTile);
     }
 }

--- a/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinCol.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinCol.cs
@@ -6,7 +6,7 @@ public class TeleportTargetTileWithinCol : EnemyTeleportTileConditionSO
 {
     public List<int> m_Cols;
 
-    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, CoordPair teleportTargetTile, CoordPair initialTarget)
+    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, GridType targetGridType, CoordPair teleportTargetTile, CoordPair initialTarget)
     {
         return m_Cols.Contains(teleportTargetTile.m_Col);
     }

--- a/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinRow.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinRow.cs
@@ -6,7 +6,7 @@ public class TeleportTargetTileWithinRow : EnemyTeleportTileConditionSO
 {
     public List<int> m_Rows;
 
-    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, CoordPair teleportTargetTile, CoordPair initialTarget)
+    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, GridType targetGridType, CoordPair teleportTargetTile, CoordPair initialTarget)
     {
         return m_Rows.Contains(teleportTargetTile.m_Row);
     }

--- a/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinTargetRange.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Conditions/TeleportTileConditions/TeleportTargetTileWithinTargetRange.cs
@@ -5,8 +5,8 @@ public class TeleportTargetTileWithinTargetRange : EnemyTeleportTileConditionSO
 {
     public RangeDefinition m_AllowedRange;
 
-    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, CoordPair teleportTargetTile, CoordPair initialTarget)
+    public override bool IsConditionMet(EnemyUnit enemyUnit, MapLogic mapLogic, GridType targetGridType, CoordPair teleportTargetTile, CoordPair initialTarget)
     {
-        return m_AllowedRange.IsWithinRange(initialTarget, teleportTargetTile);
+        return m_AllowedRange.IsWithinRange(targetGridType, targetGridType, initialTarget, teleportTargetTile);
     }
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/ActiveSkillSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/ActiveSkillSO.cs
@@ -357,7 +357,7 @@ public class ActiveSkillSO : ScriptableObject
     {
         if (TeleportTargetGrid(unit) != targetGridType)
             return false;
-        return m_TeleportTargetRules.All(x => x.IsValidTeleportTile(TeleportStartTile(unit, initialTarget), targetTile, unit));
+        return m_TeleportTargetRules.All(x => x.IsValidTeleportTile(TeleportTargetGrid(unit), TeleportStartTile(unit, initialTarget), targetTile, unit));
     }
 
     public List<CoordPair> ConstructAttackTargetTiles(CoordPair target) => m_TargetSO.ConstructAttackTargetTiles(target);

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinColRangeOfAttackerRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinColRangeOfAttackerRuleSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TargetWithinColRangeOfAttackerRuleSO", menuName = "ScriptableObject/ActiveSkills/TargetRules/TargetWithinColRangeOfAttackerRuleSO")]
+public class TargetWithinColRangeOfAttackerRuleSO : TargetLocationRuleSO
+{
+    [Header("This is valid for both types of targetting - it will work by counting the col distance by visual")]
+    public int m_ColDistance;
+
+    public override bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType)
+    {
+        return GridDistanceHelper.CalculateColDistance(GridHelper.GetSameSide(attackingUnit.UnitAllegiance), targetGridType, attackingUnit.CurrPosition, targetTile) <= m_ColDistance;
+    }
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinColRangeOfAttackerRuleSO.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinColRangeOfAttackerRuleSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0436c0905c786430baef17284ee400ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinRangeOfAttackerRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinRangeOfAttackerRuleSO.cs
@@ -3,11 +3,41 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "TargetWithinRangeOfAttackerRuleSO", menuName = "ScriptableObject/ActiveSkills/TargetRules/TargetWithinRangeOfAttackerRuleSO")]
 public class TargetWithinRangeOfAttackerRuleSO : TargetLocationRuleSO
 {
-    [Header("NOTE THAT THIS IS ONLY VALID FOR SAME-SIDE TARGETTING RULES")]
+    [Header("This is valid for both types of targetting - it will work by counting the manhatten distance")]
     public RangeDefinition m_AllowedRange;
 
     public override bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType)
     {
-        return m_AllowedRange.IsWithinRange(targetTile, attackingUnit.CurrPosition);
+        return m_AllowedRange.IsWithinRange(GridHelper.GetSameSide(attackingUnit.UnitAllegiance), targetGridType, attackingUnit.CurrPosition, targetTile);
+    }
+}
+
+public static class GridDistanceHelper
+{
+    public static int CalculateManhattenDistance(GridType startingGridType, GridType targetGridType, CoordPair startingCoordinates, CoordPair endingCoordinates)
+    {
+        return CalculateRowDistance(startingGridType, targetGridType, startingCoordinates, endingCoordinates) + CalculateColDistance(startingGridType, targetGridType, startingCoordinates, endingCoordinates);
+    }
+
+    public static int CalculateRowDistance(GridType startingGridType, GridType targetGridType, CoordPair startingCoordinates, CoordPair endingCoordinates)
+    {
+        return startingGridType != targetGridType ? startingCoordinates.m_Row + 1 + endingCoordinates.m_Row : Mathf.Abs(endingCoordinates.m_Row - startingCoordinates.m_Row);
+    }
+
+    public static int CalculateColDistance(GridType startingGridType, GridType targetGridType, CoordPair startingCoordinates, CoordPair endingCoordinates)
+    {
+        return startingGridType != targetGridType ? Mathf.Abs(MapData.NUM_COLS - 1 - startingCoordinates.m_Col - endingCoordinates.m_Col) : Mathf.Abs(startingCoordinates.m_Col - endingCoordinates.m_Col);
+    }
+
+    public static bool IsSameCol(GridType startingGridType, GridType targetGridType, CoordPair startingCoordinates, CoordPair endingCoordinates)
+    {
+        return startingGridType == targetGridType ? startingCoordinates.m_Col == endingCoordinates.m_Col : (MapData.NUM_COLS - 1 - startingCoordinates.m_Col) == endingCoordinates.m_Col;
+    }
+
+    public static int ConvertColToSameSide(GridType startingGridType, GridType targetGridType, int col)
+    {
+        if (startingGridType == targetGridType)
+            return col;
+        return MapData.NUM_COLS - 1 - col;
     }
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinRowRangeOfAttackerRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinRowRangeOfAttackerRuleSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TargetWithinRowRangeOfAttackerRuleSO", menuName = "ScriptableObject/ActiveSkills/TargetRules/TargetWithinRowRangeOfAttackerRuleSO")]
+public class TargetWithinRowRangeOfAttackerRuleSO : TargetLocationRuleSO
+{
+    [Header("This is valid for both types of targetting - it will work by counting the row distance by visual")]
+    public int m_RowDistance;
+
+    public override bool IsValidTargetTile(CoordPair targetTile, Unit attackingUnit, GridType targetGridType)
+    {
+        return GridDistanceHelper.CalculateRowDistance(GridHelper.GetSameSide(attackingUnit.UnitAllegiance), targetGridType, attackingUnit.CurrPosition, targetTile) <= m_RowDistance;
+    }
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinRowRangeOfAttackerRuleSO.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TargetWithinRowRangeOfAttackerRuleSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 068a79664619a453a882c69834c79821
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportRuleSO.cs
@@ -2,5 +2,5 @@ using UnityEngine;
 
 public abstract class TeleportRuleSO : ScriptableObject
 {
-    public abstract bool IsValidTeleportTile(CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit);
+    public abstract bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit);
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfAttackerRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfAttackerRuleSO.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TeleportTargetWithinColRangeOfAttackerRuleSO", menuName = "ScriptableObject/ActiveSkills/TeleportTargetRules/TeleportTargetWithinColRangeOfAttackerRuleSO")]
+public class TeleportTargetWithinColRangeOfAttackerRuleSO : TeleportRuleSO
+{
+    public int m_ColDistance;
+
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    {
+        return GridDistanceHelper.CalculateColDistance(GridHelper.GetSameSide(attackingUnit.UnitAllegiance), targetGridType, attackingUnit.CurrPosition, targetTile) <= m_ColDistance;
+    }
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfAttackerRuleSO.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfAttackerRuleSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfbb0f68b9f6441d08405fac302464f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfTarget.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfTarget.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TeleportTargetWithinColRangeOfTargetRuleSO", menuName = "ScriptableObject/ActiveSkills/TeleportTargetRules/TeleportTargetWithinColRangeOfTargetRuleSO")]
+public class TeleportTargetWithinColRangeOfTargetRuleSO : TeleportRuleSO
+{
+    public int m_ColDistance;
+
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    {
+        return GridDistanceHelper.CalculateColDistance(targetGridType, targetGridType, attackingUnit.CurrPosition, targetTile) <= m_ColDistance;
+    }
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfTarget.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRangeOfTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e340d00d0ce784170a34a1b5db2fbce3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinColRuleSO.cs
@@ -6,7 +6,7 @@ public class TeleportTargetWithinColRuleSO : TeleportRuleSO
 {
     public List<int> m_Cols;
 
-    public override bool IsValidTeleportTile(CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
     {
         return m_Cols.Contains(targetTile.m_Col);
     }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRangeOfAttackerRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRangeOfAttackerRuleSO.cs
@@ -3,12 +3,12 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "TeleportTargetWithinRangeOfAttackerRuleSO", menuName = "ScriptableObject/ActiveSkills/TeleportTargetRules/TeleportTargetWithinRangeOfAttackerRuleSO")]
 public class TeleportTargetWithinRangeOfAttackerRuleSO : TeleportRuleSO
 {
-    [Header("NOTE THAT THIS IS ONLY VALID FOR SAME-SIDE TARGETTING RULES")]
+    [Header("This is valid for both side targets - east and west cardinal directions don't work very well though")]
     public RangeDefinition m_AllowedRange;
 
-    public override bool IsValidTeleportTile(CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
     {
-        return m_AllowedRange.IsWithinRange(attackingUnit.CurrPosition, targetTile);
+        return m_AllowedRange.IsWithinRange(GridHelper.GetSameSide(attackingUnit.UnitAllegiance), targetGridType, attackingUnit.CurrPosition, targetTile);
     }
 }
 
@@ -19,34 +19,38 @@ public struct RangeDefinition
     public bool m_LimitCardinal;
 
     [Header("Cardinal limits - will be IGNORED if range is not limited to cardinals\nTick the directions that are allowed")]
-    [Tooltip("In direction (1, 0)")]
+    [Tooltip("In direction (1, 0) - away from the center line")]
     public bool m_North;
-    [Tooltip("In direction (-1, 0)")]
+    [Tooltip("In direction (-1, 0) - towards the center line")]
     public bool m_South;
-    [Tooltip("In direction (0, 1)")]
+    [Tooltip("In direction (0, 1) - with the center line behind you, towards the right")]
     public bool m_East;
-    [Tooltip("In direction (0, -1)")]
+    [Tooltip("In direction (0, -1) - with the center line behind you, towards the left")]
     public bool m_West;
 
     [Space]
     [Header("The distance that the tile must be within.")]
     public int m_Range;
 
-    public bool IsWithinRange(CoordPair start, CoordPair destination)
+    public bool IsWithinRange(GridType startingGridType, GridType endGridType, CoordPair start, CoordPair destination)
     {
-        bool withinDistance = start.GetDistanceToPoint(destination) <= m_Range;
+        bool withinDistance = GridDistanceHelper.CalculateManhattenDistance(startingGridType, endGridType, start, destination) <= m_Range;
 
         if (!m_LimitCardinal)
             return withinDistance;
 
+        int convertedEndCol = GridDistanceHelper.ConvertColToSameSide(startingGridType, endGridType, destination.m_Col);
         // limits cardinal but the destination is not within the cardinal directions of the start tile
-        if (destination.m_Row != start.m_Row && destination.m_Col != start.m_Col)
+        if (destination.m_Row != start.m_Row && convertedEndCol != start.m_Col)
             return false;
 
-        bool onNorthSide = destination.m_Row > start.m_Row && destination.m_Col == start.m_Col;
-        bool onSouthSide = destination.m_Row < start.m_Row && destination.m_Col == start.m_Col;
-        bool onEastSide = destination.m_Row == start.m_Row && destination.m_Col > start.m_Col;
-        bool onWestSide = destination.m_Row == start.m_Row && destination.m_Col < start.m_Col;
+        Debug.Log("Initial destination: " + destination.m_Col);
+        Debug.Log("Converted end col: " + convertedEndCol);
+        Debug.Log("Start col: " + start.m_Col);
+        bool onNorthSide = startingGridType == endGridType && destination.m_Row > start.m_Row && convertedEndCol == start.m_Col;
+        bool onSouthSide = (startingGridType != endGridType || destination.m_Row < start.m_Row) && convertedEndCol == start.m_Col;
+        bool onEastSide = destination.m_Row == start.m_Row && convertedEndCol > start.m_Col;
+        bool onWestSide = destination.m_Row == start.m_Row && convertedEndCol < start.m_Col;
 
         if (!m_North && onNorthSide)
             return false;
@@ -57,6 +61,7 @@ public struct RangeDefinition
         if (!m_West && onWestSide)
             return false;
 
+        Debug.Log("Within distance!" + endGridType + ", " + start + ", " + destination);
         return withinDistance;
     }
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRangeOfTargetRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRangeOfTargetRuleSO.cs
@@ -5,8 +5,8 @@ public class TeleportTargetWithinRangeOfTargetRuleSO : TeleportRuleSO
 {
     public RangeDefinition m_AllowedRange;
 
-    public override bool IsValidTeleportTile(CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
     {
-        return m_AllowedRange.IsWithinRange(initialTarget, targetTile);
+        return m_AllowedRange.IsWithinRange(targetGridType, targetGridType, initialTarget, targetTile);
     }
 }

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfAttackerRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfAttackerRuleSO.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TeleportTargetWithinRowRangeOfAttackerRuleSO", menuName = "ScriptableObject/ActiveSkills/TeleportTargetRules/TeleportTargetWithinRowRangeOfAttackerRuleSO")]
+public class TeleportTargetWithinRowRangeOfAttackerRuleSO : TeleportRuleSO
+{
+    public int m_RowDistance;
+
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    {
+        return GridDistanceHelper.CalculateRowDistance(GridHelper.GetSameSide(attackingUnit.UnitAllegiance), targetGridType, attackingUnit.CurrPosition, targetTile) <= m_RowDistance;
+    }
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfAttackerRuleSO.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfAttackerRuleSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3aac7d60bd9d48c882bba2d4f1aadda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfTarget.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfTarget.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TeleportTargetWithinRowRangeOfTargetRuleSO", menuName = "ScriptableObject/ActiveSkills/TeleportTargetRules/TeleportTargetWithinRowRangeOfTargetRuleSO")]
+public class TeleportTargetWithinRowRangeOfTargetRuleSO : TeleportRuleSO
+{
+    public int m_RowDistance;
+
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    {
+        return GridDistanceHelper.CalculateRowDistance(targetGridType, targetGridType, attackingUnit.CurrPosition, targetTile) <= m_RowDistance;
+    }
+}

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfTarget.cs.meta
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRangeOfTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ed7993439e614c3a89966d647147d4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRuleSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/Target Rules/TeleportRules/TeleportTargetWithinRowRuleSO.cs
@@ -6,7 +6,7 @@ public class TeleportTargetWithinRowRuleSO : TeleportRuleSO
 {
     public List<int> m_Rows;
 
-    public override bool IsValidTeleportTile(CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
+    public override bool IsValidTeleportTile(GridType targetGridType, CoordPair initialTarget, CoordPair targetTile, Unit attackingUnit)
     {
         return m_Rows.Contains(targetTile.m_Row);
     }


### PR DESCRIPTION
* Fix all same col target SO
* Add distance helper class to help calculate visual distance across entire battle map
  * Extend Range target SOs to be across entire map
  * Add within col and row range of attacker/target (does the same as a range target SO with cardinal lock but can be easier to understand) 