### PR TITLE
Add battle-level character overrides

### DIFF
--- a/Assets/Scripts/Base/UI/HUD/LevelPreviewPanel.cs
+++ b/Assets/Scripts/Base/UI/HUD/LevelPreviewPanel.cs
@@ -1,5 +1,7 @@
 using TMPro;
+using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 public struct LevelData 
 {
@@ -43,7 +45,16 @@ namespace Game.UI
         #region Transition
         private void OpenPartySelect(LevelSO levelSO)
         {
-            UIScreenManager.Instance.OpenScreen(UIScreenManager.Instance.PartySelectScreen, false, levelSO);
+            if (levelSO.m_ShowCharacterSelectScreen)
+                UIScreenManager.Instance.OpenScreen(UIScreenManager.Instance.PartySelectScreen, false, levelSO);
+            else
+            {
+                List<PlayerCharacterData> characterData = new();
+                if (CharacterDataManager.Instance.TryRetrieveLordCharacterData(out PlayerCharacterData lordData))
+                    characterData.Add(lordData);
+                characterData.AddRange(CharacterDataManager.Instance.RetrieveCharacterData(levelSO.m_LockedInCharacters.Select(x => x.m_Id), true));
+                SaveManager.Instance.Save(() => GameSceneManager.Instance.LoadLevelScene(levelSO.m_LevelId, characterData));
+            }
         }
         #endregion
 

--- a/Assets/Scripts/Battle/BattleSO.cs
+++ b/Assets/Scripts/Battle/BattleSO.cs
@@ -34,6 +34,10 @@ public class BattleSO : ScriptableObject
     public List<TutorialPageUIData> m_SetupPhaseTutorial;
     [Tooltip("Tutorial to play upon entering battle phase - leave empty for no tutorial")]
     public List<TutorialPageUIData> m_BattlePhaseTutorial;
+    [Tooltip("Whether to override the characters in the party")]
+    public bool m_OverrideCharacters = false;
+    [Tooltip("Which characters should be brought into the battle instead if overridden")]
+    public List<TutorialCharacterData> m_TutorialCharacters;
 
     [Header("Biome")]
     public bool m_OverrideBattleMap = false;

--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -405,7 +405,7 @@ public class LevelManager : Singleton<LevelManager>
         SoundManager.Instance.FadeOutAndStop(m_LevelBGM.Value);
         m_LevelBGM = null;
         BattleSO battleSO = battleNode.BattleSO;
-        GameSceneManager.Instance.LoadBattleScene(battleSO, m_CurrParty.Select(x => x.GetBattleData()).ToList(),
+        GameSceneManager.Instance.LoadBattleScene(battleSO, battleSO.m_OverrideCharacters ? battleSO.m_TutorialCharacters.Select(x => x.GetBattleData()).ToList() : m_CurrParty.Select(x => x.GetBattleData()).ToList(),
             battleSO.m_OverrideBattleMap ? battleSO.m_OverriddenBattleMapType : m_LevelSO.m_BiomeName, m_LevelRationsManager.GetInflictedTokens());
     }
     
@@ -562,7 +562,7 @@ public class LevelManager : Singleton<LevelManager>
             m_PendingRewards[RewardType.RATION] = 0;
         }
         
-        if (m_PendingRewards.ContainsKey(RewardType.EXP))
+        if (m_PendingRewards.ContainsKey(RewardType.EXP) && m_PendingRewards[RewardType.EXP] != 0)
         {
             hasEvent = true;
 

--- a/Assets/Scripts/Level/LevelSO.cs
+++ b/Assets/Scripts/Level/LevelSO.cs
@@ -27,6 +27,8 @@ public class LevelSO : ScriptableObject
     public int m_UnitLimit = 8;
     [Tooltip("Characters that must take part in this battle - the lord and any characters not owned by the player will be disregarded if it is in this list\nIf the number of characters exceeds the party limit, only the first few will be taken")]
     public List<PlayerCharacterSO> m_LockedInCharacters;
+    [Tooltip("Whether to show the party select screen at all, or directly start the level")]
+    public bool m_ShowCharacterSelectScreen = true;
     
     [Header("Rewards")]
     public List<PlayerCharacterSO> m_RewardCharacters;

--- a/Assets/Scripts/Persistent Data/Character/PlayerCharacterData.cs
+++ b/Assets/Scripts/Persistent Data/Character/PlayerCharacterData.cs
@@ -184,3 +184,27 @@ public struct PlayerCharacterBattleData
         return m_BaseData.GetUnitModelData(m_ClassSO.m_OutfitType);
     }
 } 
+
+/// <summary>
+/// Meant to serialise character data specifically for tutorial purposes, 
+/// allowing any configuration to be specified while still relying on existing
+/// character data.
+/// </summary>
+[System.Serializable]
+public class TutorialCharacterData
+{
+    public PlayerCharacterSO m_BaseData;
+
+    public int m_CurrCharaLevel = 1;
+    public PlayerClassSO m_ClassSO;
+
+    public WeaponInstanceSO m_CurrEquippedWeapon;
+
+    [Tooltip("Whether this player unit should be tracked in battle. Once this unit dies, the battle is considered lost. This could be due to a variety of reasons, e.g. the unit is a lord etc.")]
+    public bool m_CannotDieWithoutLosingBattle;
+
+    public PlayerCharacterBattleData GetBattleData()
+    {
+        return new PlayerCharacterBattleData(m_BaseData, LevellingManager.Instance.LevelUpStats(m_BaseData.m_StartingStats, new StatProgress(), m_BaseData.m_GrowthRates.FlatAugment(m_ClassSO.m_GrowthRateAugments), m_CurrCharaLevel - 1).FlatAugment(m_ClassSO.m_StatAugments), m_ClassSO, m_CurrEquippedWeapon, m_CannotDieWithoutLosingBattle, m_ClassSO.GetInflictedTokens(m_CurrCharaLevel));
+    }
+} 

--- a/Assets/Scripts/Persistent Data/Levelling/LevellingManager.cs
+++ b/Assets/Scripts/Persistent Data/Levelling/LevellingManager.cs
@@ -72,6 +72,20 @@ public class LevellingManager : Singleton<LevellingManager>
         statGrowths.ForEach(x => statGrowthDict.Add(x.Item1, x.Item2));
         return currStats.LevelUpStats(statGrowthDict);
     }
+
+    public Stats LevelUpStats(Stats initialStats, StatProgress initialStatProgress, GrowthRate growthRate, int numLevelsGained)
+    {
+        Stats currStats = initialStats;
+        for (int i = 0; i < numLevelsGained; ++i)
+        {
+            initialStatProgress.TryProgressStats(growthRate, out List<(StatType, int)> statGrowths);
+
+            Dictionary<StatType, int> statGrowthDict = new();
+            statGrowths.ForEach(x => statGrowthDict.Add(x.Item1, x.Item2));
+            currStats = currStats.LevelUpStats(statGrowthDict);
+        }
+        return currStats;
+    }
     
     public float GetProgressToNextLevel(PlayerCharacterData characterData)
     {


### PR DESCRIPTION
* Add character overrides to battleSO, allowing override of characters from party
  * Can specify character, class, weapon, level
  * Remove exp growth screen being shown after battle victory if exp gain is 0
* Add a boolean override to levelSO for proceeding directly to level without showing party select screen (will use lord + locked in characters) 