### PR TITLE
Implement post-level blanket levelling

### DIFF
--- a/Assets/Scripts/Base/UI/HUD/UIManager.cs
+++ b/Assets/Scripts/Base/UI/HUD/UIManager.cs
@@ -97,6 +97,8 @@ namespace Game.UI
 
             GlobalEvents.Scene.OnBeginSceneChange += OnBeginSceneChange;
             GlobalEvents.Scene.OnSceneTransitionCompleteEvent += OnSceneLoad;
+            GlobalEvents.WorldMap.OnBeginLevelAnimationEvent += SetVisiblityNone;
+            GlobalEvents.WorldMap.OnEndLevelAnimationEvent += SetVisibilityWorld;
         }
         
         protected override void AddDependencies()
@@ -110,6 +112,8 @@ namespace Game.UI
 
             GlobalEvents.Scene.OnBeginSceneChange -= OnBeginSceneChange;
             GlobalEvents.Scene.OnSceneTransitionCompleteEvent -= OnSceneLoad;
+            GlobalEvents.WorldMap.OnBeginLevelAnimationEvent -= SetVisiblityNone;
+            GlobalEvents.WorldMap.OnEndLevelAnimationEvent -= SetVisibilityWorld;
         }
 
         private void OnBeginSceneChange(SceneEnum _, SceneEnum _2)

--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -519,6 +519,7 @@ public class LevelManager : Singleton<LevelManager>
         if (result == LevelResultType.SUCCESS)
         {
             Debug.Log("Receiving Reward Characters");
+            CharacterDataManager.Instance.PostLevelBlanketLevelUp();
             CharacterDataManager.Instance.ReceiveCharacters(levelSo.m_RewardCharacters);
             
             foreach (var weaponReward in levelSo.m_RewardWeapons)


### PR DESCRIPTION
* Set a minimum amount of characters owned before beating a level will trigger the blanket levelling
* As of right now, it will attempt to level all characters to the lowest level of the top X characters (X = minimum amount of characters)

Additionally fix the level animation subscription I deleted off UI Manager.