### PR TITLE
Implement tile effects

### DIFF
--- a/Assets/IdHelpers/TileEffectIdHelper.asset
+++ b/Assets/IdHelpers/TileEffectIdHelper.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e7bb23f870ec40539b4d186b9bddff5, type: 3}
+  m_Name: TileEffectIdHelper
+  m_EditorClassIdentifier: 
+  m_OverrideRootFolder: 0
+  m_OverriddenRootFolder: Assets/Persistent Data

--- a/Assets/IdHelpers/TileEffectIdHelper.asset.meta
+++ b/Assets/IdHelpers/TileEffectIdHelper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 571261726c24c453ba2a532f386340ea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Persistent Data/TileEffectSOs.meta
+++ b/Assets/Persistent Data/TileEffectSOs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e39252887cd14c3084f0a8d00c45e26
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Battle/Grid/Tile.prefab
+++ b/Assets/Prefabs/Battle/Grid/Tile.prefab
@@ -33,6 +33,7 @@ Transform:
   - {fileID: 2514848623513383761}
   - {fileID: 8045155979707847837}
   - {fileID: 2188179203447812158}
+  - {fileID: 7425062909184307674}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &66012225622072951
@@ -58,6 +59,7 @@ MonoBehaviour:
   selectable: {fileID: 4690357975682213549}
   attackForecastParticleEffect: {fileID: 1587405322077031775}
   skillCastBlockedParticleEffect: {fileID: 7492937975530564092}
+  m_TileEffectObjParent: {fileID: 7425062909184307674}
 --- !u!1 &3400773091169190640
 GameObject:
   m_ObjectHideFlags: 0
@@ -252,7 +254,14 @@ MonoBehaviour:
   m_Interactable: 1
   m_TargetGraphic: {fileID: 6705659931572894427}
   isWorldSpace: 1
+  deselectOnPointerExit: 0
+  hoverAudio: {fileID: 0}
+  selectAudio: {fileID: 0}
+  submitAudio: {fileID: 0}
   onSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  onDeselect:
     m_PersistentCalls:
       m_Calls: []
   onSubmit:
@@ -261,6 +270,40 @@ MonoBehaviour:
   onPointerEnter:
     m_PersistentCalls:
       m_Calls: []
+  onPointerExit:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &6875592147703951410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7425062909184307674}
+  m_Layer: 0
+  m_Name: TileEffectParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7425062909184307674
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6875592147703951410}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1990913624422318052}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &3111489689301203310
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battle/BattleManager.cs
+++ b/Assets/Scripts/Battle/BattleManager.cs
@@ -168,6 +168,11 @@ public class BattleManager : Singleton<BattleManager>
             InstantiatePlayerUnit(playerUnitData[i], GetAvailableStartingPosition(playerUnitData[i], battleSO.m_PlayerStartingTiles));
         }
 
+        foreach (StartingTileEffect startingTileEffect in battleSO.m_StartingTileEffects)
+        {
+            m_MapLogic.ApplyTileEffectOnTile(startingTileEffect.m_GridType, startingTileEffect.m_Coordinates, startingTileEffect.m_InflictedTileEffect);
+        }
+
         m_TurnQueue.OrderTurnQueue();
 
         foreach (var objective in m_Objectives)
@@ -467,7 +472,8 @@ public class BattleManager : Singleton<BattleManager>
             return;
         }
 
-        m_TurnQueue.Tick();
+        float tick = m_TurnQueue.Tick();
+        m_MapLogic.Tick(tick);
         // Logger.Log(this.GetType().Name, m_TurnQueue.ToString(), LogLevel.LOG);
     }
     #endregion

--- a/Assets/Scripts/Battle/BattleSO.cs
+++ b/Assets/Scripts/Battle/BattleSO.cs
@@ -16,6 +16,14 @@ public class EnemyUnitPlacement
     }
 }
 
+[System.Serializable]
+public struct StartingTileEffect
+{
+    public GridType m_GridType;
+    public List<CoordPair> m_Coordinates;
+    public InflictedTileEffect m_InflictedTileEffect;
+}
+
 [CreateAssetMenu(fileName="BattleSO", menuName="ScriptableObject/Battle/BattleSO")]
 public class BattleSO : ScriptableObject
 {
@@ -26,6 +34,7 @@ public class BattleSO : ScriptableObject
     /// List of coordinates that the player units start in
     /// </summary>
     public List<CoordPair> m_PlayerStartingTiles;
+    public List<StartingTileEffect> m_StartingTileEffects;
     public int m_ExpReward;
     public AudioDataSO m_BattleBGM;
 

--- a/Assets/Scripts/Battle/Grid/GridLogic.cs
+++ b/Assets/Scripts/Battle/Grid/GridLogic.cs
@@ -100,6 +100,13 @@ public class GridLogic : MonoBehaviour
     }
     #endregion
 
+    #region Tick
+    public void Tick()
+    {
+        
+    }
+    #endregion
+
     #region Graphics
     public void ColorReachablePoints(HashSet<PathNode> reachablePoints)
     {

--- a/Assets/Scripts/Battle/Grid/Pathfinder.cs
+++ b/Assets/Scripts/Battle/Grid/Pathfinder.cs
@@ -2,12 +2,15 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-// can add more tile types like trap or cliff in the future
-// if calculations become exceedingly class dependent it should be given to the class
-// to calculate
+/// <summary>
+/// Kindly keep this updated :)
+/// Can be used for more broad categories e.g. NORMAL means all units can cross
+/// Something like FLYERS may mean only flying units can cross
+/// </summary>
 public enum TileType
 {
-    NORMAL
+    NORMAL,
+    IMPASSABLE
 }
 
 /// <summary>
@@ -15,15 +18,14 @@ public enum TileType
 /// </summary>
 public class TileData
 {
-    public TileType m_TileType;
+    public TileType TileType => m_CurrTileEffect == null ? TileType.NORMAL : m_CurrTileEffect.TileType;
     // this follows the assumption that units cannot cross over the line, otherwise this requires information on the alliance
     public bool m_IsOccupied;
     public Unit m_CurrUnit;
     public TileEffect m_CurrTileEffect;
 
-    public TileData(TileType tileType, bool isOccupied)
+    public TileData(bool isOccupied)
     {
-        m_TileType = tileType;
         m_IsOccupied = isOccupied;
         m_CurrUnit = null;
         m_CurrTileEffect = null;
@@ -42,16 +44,30 @@ public class TileData
         }
     }
 
-    public void ApplyEffect(TileEffect tileEffect)
+    public bool TryApplyEffect(InflictedTileEffect tileEffect)
     {
-        if (m_CurrTileEffect != null && tileEffect.TileType == m_CurrTileEffect.TileType)
+        if (m_CurrTileEffect != null && m_CurrTileEffect.IsPermanent)
+            return false;
+
+        if (m_CurrTileEffect != null && tileEffect.m_TileEffect == m_CurrTileEffect.m_TileEffectSO)
         {
-            m_CurrTileEffect.TopUp(tileEffect.m_TimeRemaining);
+            m_CurrTileEffect.TopUp(tileEffect.m_InitialTime);
         }
         else
         {
-            m_CurrTileEffect = tileEffect;
+            m_CurrTileEffect = new TileEffect(tileEffect.m_TileEffect, tileEffect.m_InitialTime);
         }
+
+        return true;
+    }
+
+    public bool TryApplyEffectOnUnit()
+    {
+        if (!m_IsOccupied || m_CurrTileEffect == null)
+            return false;
+
+        m_CurrTileEffect.ApplyEffects(m_CurrUnit);
+        return true;
     }
 }
 
@@ -273,9 +289,8 @@ public static class Pathfinder
     private static bool IsTraversableTile(MapData map, CoordPair point, params TileType[] traversableTiles)
     {
         TileData tile = map.RetrieveTile(point);
-        if (!Array.Exists(traversableTiles, x => x == tile.m_TileType))
+        if (!Array.Exists(traversableTiles, x => x == tile.TileType))
             return false;
-
         return true;
     }
 }

--- a/Assets/Scripts/Battle/Grid/Pathfinder.cs
+++ b/Assets/Scripts/Battle/Grid/Pathfinder.cs
@@ -49,7 +49,7 @@ public class TileData
         if (m_CurrTileEffect != null && m_CurrTileEffect.IsPermanent)
             return false;
 
-        if (m_CurrTileEffect != null && tileEffect.m_TileEffect == m_CurrTileEffect.m_TileEffectSO)
+        if (m_CurrTileEffect != null && tileEffect.Id == m_CurrTileEffect.Id)
         {
             m_CurrTileEffect.TopUp(tileEffect.m_InitialTime);
         }

--- a/Assets/Scripts/Battle/Grid/Pathfinder.cs
+++ b/Assets/Scripts/Battle/Grid/Pathfinder.cs
@@ -19,12 +19,39 @@ public class TileData
     // this follows the assumption that units cannot cross over the line, otherwise this requires information on the alliance
     public bool m_IsOccupied;
     public Unit m_CurrUnit;
+    public TileEffect m_CurrTileEffect;
 
     public TileData(TileType tileType, bool isOccupied)
     {
         m_TileType = tileType;
         m_IsOccupied = isOccupied;
         m_CurrUnit = null;
+        m_CurrTileEffect = null;
+    }
+
+    public void Tick(float passedTime, VoidEvent clearEvent)
+    {
+        if (m_CurrTileEffect != null)
+        {
+            m_CurrTileEffect.Tick(passedTime);
+            if (m_CurrTileEffect.IsEmpty)
+            {
+                clearEvent?.Invoke();
+                m_CurrTileEffect = null;
+            }
+        }
+    }
+
+    public void ApplyEffect(TileEffect tileEffect)
+    {
+        if (m_CurrTileEffect != null && tileEffect.TileType == m_CurrTileEffect.TileType)
+        {
+            m_CurrTileEffect.TopUp(tileEffect.m_TimeRemaining);
+        }
+        else
+        {
+            m_CurrTileEffect = tileEffect;
+        }
     }
 }
 
@@ -58,6 +85,20 @@ public class MapData
     public void UpdateTile(CoordPair coordPair, TileData tile)
     {
         tileMap[coordPair.m_Row, coordPair.m_Col] = tile;
+    }
+
+    public void Tick()
+    {
+        for (int r = 0; r < NUM_ROWS; ++r)
+        {
+            for (int c = 0; c < NUM_COLS; ++c)
+            {
+                if (tileMap[r, c].m_CurrTileEffect != null)
+                {
+
+                }
+            }
+        }
     }
 
     public TileData RetrieveTile(CoordPair coordPair)

--- a/Assets/Scripts/Battle/Grid/TileEffectSO.cs
+++ b/Assets/Scripts/Battle/Grid/TileEffectSO.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public enum TileEffectType 
+{
+
+}
+
+public class TileEffectSO : ScriptableObject
+{
+    public TileEffect GetTileEffect()
+    {
+        return null;
+    }
+}
+
+public class TileEffect 
+{
+
+}

--- a/Assets/Scripts/Battle/Grid/TileEffectSO.cs
+++ b/Assets/Scripts/Battle/Grid/TileEffectSO.cs
@@ -2,16 +2,24 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+[System.Serializable]
 public struct InflictedTileEffect
 {
     public TileEffectSO m_TileEffect;
     public float m_InitialTime;
+
+    public TileType TileType => m_TileEffect.m_TileType;
+    public GameObject[] TileEffectObjs => m_TileEffect.m_TileGameObjects;
 }
 
+[CreateAssetMenu(fileName = "TileEffectSO", menuName = "ScriptableObject/TileEffectSO")]
 public class TileEffectSO : ScriptableObject
 {
     [Header("Details")]
     public TileType m_TileType;
+    [Tooltip("Whether this tile effect is permanent and cannot be replaced")]
+    public bool m_IsPermanent = false;
+    [Tooltip("If permanent, this will not matter")]
     public float m_MaxTime;
 
     [Tooltip("Note that some skill types won't have any effect")]
@@ -33,8 +41,8 @@ public class TileEffectSO : ScriptableObject
     [Tooltip("Sign is important!")]
     public float m_ChangeManaAmount;
 
-    [Tooltip("Game object to spawn on top of the tile")]
-    public GameObject m_TileGameObject;
+    [Tooltip("Game objects to spawn on top of the tile")]
+    public GameObject[] m_TileGameObjects;
     // VFX to spawn
     // public List<VFXSO> m_TileVfx;
 
@@ -45,8 +53,9 @@ public class TileEffect
 {
     public TileEffectSO m_TileEffectSO;
     public float m_TimeRemaining;
-    public bool IsEmpty => m_TimeRemaining <= 0;
+    public bool IsEmpty => !IsPermanent && m_TimeRemaining <= 0;
     public TileType TileType => m_TileEffectSO.m_TileType;
+    public bool IsPermanent => m_TileEffectSO.m_IsPermanent;
 
     public TileEffect(TileEffectSO tileEffectSO, float inflictedTime)
     {

--- a/Assets/Scripts/Battle/Grid/TileEffectSO.cs
+++ b/Assets/Scripts/Battle/Grid/TileEffectSO.cs
@@ -8,7 +8,7 @@ public struct InflictedTileEffect
     public TileEffectSO m_TileEffect;
     public float m_InitialTime;
 
-    public TileType TileType => m_TileEffect.m_TileType;
+    public int Id => m_TileEffect.m_Id;
     public GameObject[] TileEffectObjs => m_TileEffect.m_TileGameObjects;
 }
 
@@ -16,6 +16,8 @@ public struct InflictedTileEffect
 public class TileEffectSO : ScriptableObject
 {
     [Header("Details")]
+    public int m_Id;
+    [Tooltip("Indicates what units can traverse over this tile while this effect is active")]
     public TileType m_TileType;
     [Tooltip("Whether this tile effect is permanent and cannot be replaced")]
     public bool m_IsPermanent = false;
@@ -55,6 +57,7 @@ public class TileEffect
     public float m_TimeRemaining;
     public bool IsEmpty => !IsPermanent && m_TimeRemaining <= 0;
     public TileType TileType => m_TileEffectSO.m_TileType;
+    public int Id => m_TileEffectSO.m_Id;
     public bool IsPermanent => m_TileEffectSO.m_IsPermanent;
 
     public TileEffect(TileEffectSO tileEffectSO, float inflictedTime)

--- a/Assets/Scripts/Battle/Grid/TileEffectSO.cs
+++ b/Assets/Scripts/Battle/Grid/TileEffectSO.cs
@@ -1,19 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
-public enum TileEffectType 
+public struct InflictedTileEffect
 {
-
+    public TileEffectSO m_TileEffect;
+    public float m_InitialTime;
 }
 
 public class TileEffectSO : ScriptableObject
 {
-    public TileEffect GetTileEffect()
-    {
-        return null;
-    }
+    [Header("Details")]
+    public TileType m_TileType;
+    public float m_MaxTime;
+
+    [Tooltip("Note that some skill types won't have any effect")]
+    public SkillEffectType[] m_EffectTypes;
+
+    [Header("Effects")]
+    public float m_DamageAmount;
+
+    [Space]
+    public List<InflictedStatusEffect> m_InflictedStatusEffects;
+    public List<InflictedToken> m_InflictedTokens;
+
+    [Space]
+    [Tooltip("What this skill will cleanse")]
+    public List<StatusType> m_CleansedStatusTypes;
+
+    [Space]
+    public float m_HealAmount;
+    [Tooltip("Sign is important!")]
+    public float m_ChangeManaAmount;
+
+    [Tooltip("Game object to spawn on top of the tile")]
+    public GameObject m_TileGameObject;
+    // VFX to spawn
+    // public List<VFXSO> m_TileVfx;
+
+    public bool ContainsEffectType(SkillEffectType skillEffectType) => m_EffectTypes.Contains(skillEffectType);
 }
 
 public class TileEffect 
 {
+    public TileEffectSO m_TileEffectSO;
+    public float m_TimeRemaining;
+    public bool IsEmpty => m_TimeRemaining <= 0;
+    public TileType TileType => m_TileEffectSO.m_TileType;
 
+    public TileEffect(TileEffectSO tileEffectSO, float inflictedTime)
+    {
+        m_TileEffectSO = tileEffectSO;
+        m_TimeRemaining = Mathf.Min(inflictedTime, m_TileEffectSO.m_MaxTime);
+    }
+
+    public void TopUp(float inflictedTime)
+    {
+        m_TimeRemaining = Mathf.Min(m_TimeRemaining + inflictedTime, m_TileEffectSO.m_MaxTime);
+    }
+
+    public void Tick(float passedTime)
+    {
+        m_TimeRemaining -= passedTime;
+    }
+
+    public void ApplyEffects(Unit unit)
+    {
+        if (m_TileEffectSO.ContainsEffectType(SkillEffectType.DEALS_DAMAGE))
+            unit.TakeDamage(m_TileEffectSO.m_DamageAmount);
+        if (m_TileEffectSO.ContainsEffectType(SkillEffectType.DEALS_STATUS_OR_TOKENS))
+        {
+            List<StatusEffect> statusEffects = m_TileEffectSO.m_InflictedStatusEffects.Select(x => new StatusEffect(x.m_StatusEffect, x.m_Stack)).ToList();
+            List<InflictedToken> inflictedTokens = m_TileEffectSO.m_InflictedTokens;
+            unit.InflictTokens(inflictedTokens, null);
+            unit.InflictStatus(statusEffects);
+        }
+        if (m_TileEffectSO.ContainsEffectType(SkillEffectType.HEAL))
+            unit.Heal(m_TileEffectSO.m_HealAmount);
+        if (m_TileEffectSO.ContainsEffectType(SkillEffectType.ALTER_MANA))
+            unit.AlterMana(m_TileEffectSO.m_ChangeManaAmount);
+        if (m_TileEffectSO.ContainsEffectType(SkillEffectType.CLEANSE))
+            unit.Cleanse(m_TileEffectSO.m_CleansedStatusTypes);
+    }
 }

--- a/Assets/Scripts/Battle/Grid/TileEffectSO.cs.meta
+++ b/Assets/Scripts/Battle/Grid/TileEffectSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08c01f85f515e4c16b5d2ac5a98f32ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/Grid/TileVisual.cs
+++ b/Assets/Scripts/Battle/Grid/TileVisual.cs
@@ -52,6 +52,8 @@ public class TileVisual : MonoBehaviour
     [SerializeField]
     private ParticleSystem skillCastBlockedParticleEffect;
 
+    [SerializeField] private Transform m_TileEffectObjParent;
+
     private TileState m_CurrState = TileState.NONE;
 
     private Color CurrentStateDefaultColor => m_CurrState switch
@@ -154,6 +156,25 @@ public class TileVisual : MonoBehaviour
         else
         {
             skillCastBlockedParticleEffect.Stop();
+        }
+    }
+    #endregion
+
+    #region Tile Effects
+    public void SpawnTileEffects(params GameObject[] tileEffectObjs)
+    {
+        ClearEffects();
+        foreach (GameObject gameObject in tileEffectObjs)
+        {
+            Instantiate(gameObject, m_TileEffectObjParent);
+        }
+    }
+
+    public void ClearEffects()
+    {
+        foreach (Transform child in m_TileEffectObjParent)
+        {
+            Destroy(child.gameObject);
         }
     }
     #endregion

--- a/Assets/Scripts/Battle/Map/MapLogic.cs
+++ b/Assets/Scripts/Battle/Map/MapLogic.cs
@@ -287,4 +287,24 @@ public class MapLogic : MonoBehaviour
         RetrieveGrid(teleportTargetGrid).SwapTiles(teleportStartPoint, teleportDestination);
     }
     #endregion
+
+    #region Tick
+    public void Tick(float tickTime)
+    {
+        m_EnemyGrid.Tick(tickTime);
+        m_PlayerGrid.Tick(tickTime);
+    }
+    #endregion
+
+    #region Tile Effect
+    public void ApplyTileEffectOnUnit(GridType gridType, Unit unit)
+    {
+        RetrieveGrid(gridType).TryApplyTileEffectsOnUnit(unit);
+    }
+
+    public void ApplyTileEffectOnTile(GridType gridType, List<CoordPair> coordinates, InflictedTileEffect inflictedTileEffect)
+    {
+        RetrieveGrid(gridType).TryApplyEffectOnTiles(coordinates, inflictedTileEffect);
+    }
+    #endregion
 }

--- a/Assets/Scripts/Battle/TurnManagement/EnemyTurnManager.cs
+++ b/Assets/Scripts/Battle/TurnManagement/EnemyTurnManager.cs
@@ -8,27 +8,28 @@ public class EnemyTurnManager : TurnManager
         Logger.Log(this.GetType().Name, "Start enemy turn with " + m_CurrUnit.name, LogLevel.LOG);
 
         m_CurrUnit.PreTick();
+        m_MapLogic.ApplyTileEffectOnUnit(GridType.ENEMY, m_CurrUnit);
 
         if (m_CurrUnit.IsDead)
         {
             m_CurrUnit.Die();
-            CompleteTurn();
+            EndTurn();
             return;
         }
 
         if (!PreTurn(enemyUnit))
         {
-            CompleteTurn();
+            EndTurn();
             return;
         }   
 
         GlobalEvents.Battle.EnemyTurnStartEvent?.Invoke();
         GlobalEvents.Battle.PreviewCurrentUnitEvent?.Invoke(m_CurrUnit);
 
-        enemyUnit.PerformAction(m_MapLogic, CompleteTurn);
+        enemyUnit.PerformAction(m_MapLogic, EndTurn);
     }
 
-    private void CompleteTurn()
+    private void EndTurn()
     {
         m_CurrUnit.PostTick();
         m_CompleteTurnEvent?.Invoke(m_CurrUnit);

--- a/Assets/Scripts/Battle/TurnManagement/PlayerTurnManager.cs
+++ b/Assets/Scripts/Battle/TurnManagement/PlayerTurnManager.cs
@@ -94,6 +94,7 @@ public class PlayerTurnManager : TurnManager
 
         m_CurrUnit = playerUnit;
         m_CurrUnit.PreTick();
+        m_MapLogic.ApplyTileEffectOnUnit(GridType.PLAYER, m_CurrUnit);
 
         GlobalEvents.Battle.PreviewCurrentUnitEvent?.Invoke(m_CurrUnit);
 
@@ -287,7 +288,7 @@ public class PlayerTurnManager : TurnManager
         if (!CheckSkillManaRequirement(m_CurrUnit, selectedSkill)) return false;
         if (!CheckCooldownRequirement(m_CurrUnit, selectedSkill)) return false;
 
-        if (m_MapLogic.CanPerformSkill(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType, true))
+        if (m_MapLogic.CanPerformSkill(SelectedSkill, m_CurrUnit, selectedTileVisual.Coordinates, selectedTileVisual.GridType, SelectedSkill.RequiresOccupiedTiles))
         {
             if (selectedSkill.ContainsSkillType(SkillEffectType.TELEPORT))
             {
@@ -380,6 +381,11 @@ public class PlayerTurnManager : TurnManager
             //m_TileToPath.Clear();
             //m_TileToPath.Add(node.m_Coordinates, node);
             m_CurrUnit.ConsumeTokens(TokenConsumptionType.CONSUME_ON_MOVE);
+
+            m_MapLogic.ApplyTileEffectOnUnit(GridType.PLAYER, m_CurrUnit);
+            if (m_CurrUnit.IsDead)
+                m_CurrUnit.Die();
+
             EndTurn();
         }
         //TransitToAction(PlayerTurnState.SELECTING_MOVEMENT_SQUARE);

--- a/Assets/Scripts/Battle/TurnQueue.cs
+++ b/Assets/Scripts/Battle/TurnQueue.cs
@@ -102,10 +102,10 @@ public class TurnQueue
         m_Turns.Sort(UnitSpeedComparer);
     }
 
-    public void Tick()
+    public float Tick()
     {
         if (m_Turns.Count <= 0)
-            return;
+            return 0;
 
         float tick = Mathf.Min(TICK_AMOUNT, m_Turns[0].m_TimeRemaining);
         foreach (TurnWrapper turnWrapper in m_Turns)
@@ -114,6 +114,7 @@ public class TurnQueue
         }
         m_AccumulatedTime += tick;
         GlobalEvents.Battle.BattleTimeTickEvent?.Invoke(m_AccumulatedTime);
+        return tick;
     }
 
     #region Helper

--- a/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillAction.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyActiveSkillAction.cs
@@ -89,12 +89,12 @@ public class EnemyActiveSkillAction : EnemyActionInstance
             for (int c = 0; c < MapData.NUM_COLS; ++c)
             {
                 CoordPair coordinates = new CoordPair(r, c);
-                if (mapLogic.CanPerformSkill(m_ActiveSkill, enemyUnit, coordinates, targetGridType, true) && m_TargetConditions.All(cond => cond.IsConditionMet(enemyUnit, mapLogic, coordinates, m_ActiveSkill)) && (!isTeleportSkill || IsValidTeleportTargetTile(enemyUnit, mapLogic, coordinates)))
+                if (mapLogic.CanPerformSkill(m_ActiveSkill, enemyUnit, coordinates, targetGridType, m_ActiveSkill.RequiresOccupiedTiles) && m_TargetConditions.All(cond => cond.IsConditionMet(enemyUnit, mapLogic, coordinates, m_ActiveSkill)) && (!isTeleportSkill || IsValidTeleportTargetTile(enemyUnit, mapLogic, coordinates)))
                 {
                     targetablePositions = targetablePositions.Append(coordinates);
                     hasPossibleAttackPosition = true;
                 }
-                if (mapLogic.CanPerformSkill(m_ActiveSkill, enemyUnit, coordinates, targetGridType, false))
+                if (mapLogic.CanPerformSkill(m_ActiveSkill, enemyUnit, coordinates, targetGridType))
                 {
                     targetablePositionsIgnoreOccupiedAndAdditionalConditions = targetablePositionsIgnoreOccupiedAndAdditionalConditions.Append(coordinates);
                 }

--- a/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyMoveAction.cs
+++ b/Assets/Scripts/Battle/Units/EnemyAI/Actions/EnemyMoveAction.cs
@@ -19,8 +19,17 @@ public class EnemyMoveActionWrapper : EnemyActionWrapper
         // calculate the final tile that the unit wants to move towards
         CoordPair finalTile = MoveAction.GetChosenTile(enemyUnit, mapLogic, m_CanOccupyTiles);
         
-        mapLogic.TryReachTile(GridType.ENEMY, enemyUnit, finalTile, completeActionEvent);
+        mapLogic.TryReachTile(GridType.ENEMY, enemyUnit, finalTile, () => OnMoveComplete(enemyUnit, mapLogic, completeActionEvent));
+    }
+
+    private void OnMoveComplete(EnemyUnit enemyUnit, MapLogic mapLogic, VoidEvent completeActionEvent)
+    {
         enemyUnit.ConsumeTokens(TokenConsumptionType.CONSUME_ON_MOVE);
+        mapLogic.ApplyTileEffectOnUnit(GridType.ENEMY, enemyUnit);
+        if (enemyUnit.IsDead)
+            enemyUnit.Die();
+
+        completeActionEvent?.Invoke();
     }
 
     public override HashSet<ActiveSkillSO> GetNestedActiveSkills()

--- a/Assets/Scripts/Battle/Units/Unit.cs
+++ b/Assets/Scripts/Battle/Units/Unit.cs
@@ -443,7 +443,7 @@ public abstract class Unit : MonoBehaviour, IHealth, ICanAttack, IFlatStatChange
         return HasToken(TokenType.EVADE);
     }
 
-    private void Cleanse(List<StatusType> statusTypes)
+    public void Cleanse(List<StatusType> statusTypes)
     {
         m_StatusManager.CleanseStatusTypes(statusTypes);
     }
@@ -481,7 +481,7 @@ public abstract class Unit : MonoBehaviour, IHealth, ICanAttack, IFlatStatChange
         return CurrentMana >= skill.m_ConsumedMana;
     }
 
-    private void AlterMana(float amount)
+    public void AlterMana(float amount)
     {
         Logger.Log(this.GetType().Name, $"Add {amount} mana to {name}", name, this.gameObject, LogLevel.LOG);
         var max = MaxMana;

--- a/Assets/Scripts/Helper/Tools/IdHelper/TileEffectIdHelper.cs
+++ b/Assets/Scripts/Helper/Tools/IdHelper/TileEffectIdHelper.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+#if UNITY_EDITOR
+[CreateAssetMenu(fileName = "TileEffectIdHelper", menuName = "ScriptableObject/IdHelpers/TileEffectIdHelper")]
+public class TileEffectIdHelper : IdHelper<TileEffectSO>
+{
+    protected override string InstanceSoName => "StatusEffectSO";
+
+    protected override void EditInstanceSoId(TileEffectSO tileEffectSO, int newId)
+    {
+        tileEffectSO.m_Id = newId;
+    }
+
+    protected override int GetInstanceSoId(TileEffectSO tileEffectSO)
+    {
+        return tileEffectSO.m_Id;
+    }
+}
+#endif

--- a/Assets/Scripts/Helper/Tools/IdHelper/TileEffectIdHelper.cs.meta
+++ b/Assets/Scripts/Helper/Tools/IdHelper/TileEffectIdHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e7bb23f870ec40539b4d186b9bddff5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistent Data/Active Skills/ActiveSkillSO.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/ActiveSkillSO.cs
@@ -78,6 +78,10 @@ public class ActiveSkillSO : ScriptableObject
     [Space]
     [Tooltip("What this skill will cleanse")]
     public List<StatusType> m_CleansedStatusTypes;
+
+    [Space]
+    [Tooltip("The tile effects to be applied - these will be ignored if the skill does not apply tile effects")]
+    public InflictedTileEffect m_InflictedTileEffect;
     
     [Header("Animations")]
     public bool m_TargetWillPlayHurtAnimation = false;
@@ -112,7 +116,6 @@ public class ActiveSkillSO : ScriptableObject
             return sprite;
         }
     }
-
     
     public (Sprite sprite, bool isAlly) GetTargetPositioningSprite
     {
@@ -159,6 +162,7 @@ public class ActiveSkillSO : ScriptableObject
     public bool IsOpposingSideTarget => !IsSelfTarget && m_TargetRules.Any(x => x is TargetOpposingSideRuleSO);
     public bool HasAttackerLimitations => m_TargetRules.Any(x => x is IAttackerRule);
     public bool HasTargetLimitations => m_TargetRules.Any(x => x is TargetLocationRuleSO);
+    public bool RequiresOccupiedTiles => !ContainsSkillType(SkillEffectType.APPLY_TILE_EFFECT);
     public GridType TargetGridType(UnitAllegiance unitAllegiance) => IsOpposingSideTarget ? GridHelper.GetOpposingSide(unitAllegiance) : GridHelper.GetSameSide(unitAllegiance);
     // depends on whether attacks that target the opposing side but only deal status effects will still use the attack animation
     // public bool WillPlaySupportAnimation => !DealsDamage && !m_TargetRules.Any(x => x is TargetOpposingSideRuleSO);

--- a/Assets/Scripts/Persistent Data/Active Skills/SkillEnums.cs
+++ b/Assets/Scripts/Persistent Data/Active Skills/SkillEnums.cs
@@ -7,7 +7,8 @@ public enum SkillEffectType
     SUMMON,
     ALTER_MANA,
     TELEPORT,
-    CLEANSE
+    CLEANSE,
+    APPLY_TILE_EFFECT
 }
 
 public enum SkillType


### PR DESCRIPTION
* Implement tile effect SOs
  * Follows an ID system, so an ID helper has been created
  * Each tile effect can be permanent and can have a range of effects
  * A tile type is also indicated (as a general way to say this tile is accessible to all units, to only flyers, to no units, etc.)
* Apply tile effects on grid during skill
  * Skills with tile effects are allowed to hit non-occupied tiles, but only the tile effect will come into play
  * Tile effect is spawned after attack animations, and involves spawning in game objects in the tile visual which are cleared once the effect passes
* Add initial tile effects to battle SO 
* Tick tile effects by time passed and clear once time hits 0
* Apply tile effects to unit on turn start and on moving to an affected tile (can kill the unit)

TODO:
* Game objects created by tile effects are not tied into skill animation system so they're still visible during skill animation
  * Haven't tried spawning particle systems yet so might need to work that in
* Not sure how nicely the tile colors will work with tile effect game objects/particle systems  
* If a unit attacks a non-occupied tile the animation still plays but it looks a little awkward